### PR TITLE
feat(cli): add REPL — bell with no arguments drops into interactive mode

### DIFF
--- a/apps/docs/docs/guide/examples.md
+++ b/apps/docs/docs/guide/examples.md
@@ -3,36 +3,73 @@
 Below are a collection of examples showing Bell in action. These files are pulled directly from the `examples/` directory of the repository.
 
 ## Basic GET Request
-A simple example of setting a URL and parameters, then executing a GET request and logging the status.
+
+A simple example of setting a URL and parameters, then executing a GET request.
 
 <<< @/../../../examples/0-basicGetRequest/post.GET.bel
 
-## Login and POST (Workflow)
-Demonstrates a multi-step workflow in a single file.
-
-<<< @/../../../examples/1-loginAndPost/loginAndPostOneFile.bel
-
-## Post with Validation
-Shows how to import JSON data, validate it against a type, and perform expectations on the response.
-
-<<< @/../../../examples/5-postWithValidateAndExpect/post.POST.bel
-
-## Environment Switching
-Shows how to load environment configurations and switch between them.
-
-<<< @/../../../examples/6-environment/environment.GET.bel
-
 ## User Input
+
 Prompt the user for data during execution.
 
 <<< @/../../../examples/0-basicGetRequest/postWithUserInput.GET.bel
 
-## Security Warnings
-Prompt for confirmation before performing sensitive operations.
+## Search with URL Breakdown
 
-<<< @/../../../examples/7-securityWarnings/deleteUserProdWarning.bel
+Build a URL from a base domain and query parameters.
+
+<<< @/../../../examples/3-searchWithUrlBreakdown/searchWithUrl.GET.bel
+
+## Login and POST (Single File)
+
+A multi-step workflow in a single file: log in, save the token, then make an authenticated POST.
+
+<<< @/../../../examples/1-loginAndPost/loginAndPostOneFile.bel
 
 ## Multi-file Organization
-Split your scripts into reusable components.
 
-<<< @/../../../examples/2-loginAndPostAndDelete-require/loginAndPostImport.bel
+Split scripts into reusable files. The main file uses `request` to run each step; exported variables carry over between files.
+
+::: code-group
+
+<<< @/../../../examples/2-loginAndPostAndDelete-require/loginAndPostImport.bel [loginAndPostImport.bel]
+
+<<< @/../../../examples/2-loginAndPostAndDelete-require/1-login.POST.bel [1-login.POST.bel]
+
+<<< @/../../../examples/2-loginAndPostAndDelete-require/2-post.POST.bel [2-post.POST.bel]
+
+<<< @/../../../examples/2-loginAndPostAndDelete-require/3-delete.DELETE.bel [3-delete.DELETE.bel]
+
+<<< @/../../../examples/2-loginAndPostAndDelete-require/cred.bel [cred.bel]
+
+:::
+
+## Post with Validation
+
+Import JSON data, validate it against a TypeScript type, and assert on the response.
+
+::: code-group
+
+<<< @/../../../examples/5-postWithValidateAndExpect/post.POST.bel [post.POST.bel]
+
+<<< @/../../../examples/5-postWithValidateAndExpect/request.json [request.json]
+
+:::
+
+## Environment Switching
+
+Load an environment config and let the user choose between dev, staging, and production.
+
+::: code-group
+
+<<< @/../../../examples/6-environment/environment.GET.bel [environment.GET.bel]
+
+<<< @/../../../examples/6-environment/envConfig.json [envConfig.json]
+
+:::
+
+## Security Warnings
+
+Use `warn` to require confirmation before sending a request to a sensitive endpoint.
+
+<<< @/../../../examples/7-securityWarnings/deleteUserProdWarning.bel

--- a/apps/docs/docs/guide/syntax.md
+++ b/apps/docs/docs/guide/syntax.md
@@ -2,104 +2,131 @@
 
 The Bell language is designed to be as close to plain English as possible for making HTTP requests.
 
-## Variables and Assignments
+## Variables and String Interpolation
 
-You can define variables to store values for reuse.
+Assign values to variables with `=`. Use `{variableName}` to interpolate a variable into a string.
 
-```bel
-apiKey = "my-secret-token"
-baseUrl = "https://api.example.com"
-```
+<<< @/../../../examples/guide/variables.bel
 
 ## Request Building
 
-Use these keywords to build your HTTP request.
+Use these keywords to build up your HTTP request before sending it.
 
 ### `url`
-Sets the full base URL for the request.
-```bel
-url "https://api.example.com"
-```
+
+Sets the full base URL for the request. When an environment is active, `path` should be used instead and the base URL comes from the environment config.
 
 ### `path`
-Appends a path to the base URL (if an environment or URL is set).
-```bel
-path "/users/123"
-```
+
+Appends a path segment to the base URL.
+
+<<< @/../../../examples/guide/url-path.bel
 
 ### `param`
-Adds a query parameter to the URL.
-```bel
-param "lat"    30.1234
-param "lng"    -40.1268
-param "output" "json"
-```
 
-Can also set a param just using a variable. This will yield `?variableName=<variableValue>`.
-```bel
-param variableName
-```
+Adds query parameters to the URL.
+
+<<< @/../../../examples/guide/params.bel
 
 ### `header` and `headers`
-Adds an HTTP header to the request.
-```bel
-header "Authorization"  "Bearer {token}"
-header "Content-Type"   "application/json"
-```
 
-Or sets the headers outright
-```bel
-headers {
-  "Authorization": "Bearer {token}"
-}
-```
+Adds HTTP headers to the request. Use `header` for individual headers or `headers` to set them all at once with an object.
+
+<<< @/../../../examples/guide/headers.bel
 
 ### `body`
-Sets the request body (usually used with POST or PUT). Supports multi-line declarations.
-```bel
-body {
-  "name": "John Doe",
-  "email": "john@example.com"
-}
-```
+
+Sets the request body. Typically used with `POST`, `PUT`, and `PATCH`.
+
+<<< @/../../../examples/guide/body.bel
 
 ## Sending a Request
 
-When bell encounters `GET`, `POST`, `PATCH` or other HTTP method, it sends the currently built request.
+Writing an HTTP method keyword dispatches the currently built request.
 
-```bel
-POST
-```
+<<< @/../../../examples/guide/http-methods.bel
+
+## Logging
+
+Use `log` to print a value to the console during execution. You can log any expression, including response data, variables, and the current URL.
+
+<<< @/../../../examples/guide/log.bel
+
+## Response
+
+After a request is dispatched, the `response` object is set. Bell keeps a history of all responses made in a file.
+
+<<< @/../../../examples/guide/response.bel
 
 ## User Interaction
 
 ### `input`
-Prompts the user for a value during execution.
-```bel
-id = input("Enter user ID")
-url "https://api.example.com/users/{id}"
-```
+
+Prompts the user for a value at runtime. The result can be assigned to a variable or used inline.
+
+<<< @/../../../examples/guide/input.bel
 
 ### `warn`
-Displays a warning message and requires user confirmation before proceeding.
-```bel
-# Prompts for confirmation and returns the value if confirmed
-prodUrl = warn "production.com"
 
-# Can also be used as a statement
-warn "You are about to modify production data!"
-```
+Displays a confirmation prompt before continuing. As an expression, it returns the value if confirmed. As a statement, it shows the message and waits for confirmation.
 
-## `expect`
-Bell files can be used as test files with the `expect` command.
-```bel
-url "example.com"
-expect response.code === 200
-```
+<<< @/../../../examples/guide/warn.bel
+
+## Testing
+
+### `expect`
+
+Asserts that an expression is truthy. If the assertion fails, the file exits with an error. Use Bell files as lightweight API test suites.
+
+<<< @/../../../examples/guide/expect.bel
+
+### `validate`
+
+Validates that a value matches a TypeScript type at runtime. Useful for verifying request and response shapes stay in sync with your type definitions.
+
+<<< @/../../../examples/guide/validate.bel
+
+## Imports
+
+Bell supports three import forms.
+
+<<< @/../../../examples/guide/import.bel
+
+## Environments
+
+Environments let you switch between configurations (dev, staging, prod) without changing your Bell files. Define them in a JSON config and load it with an anonymous import.
+
+The config JSON maps environment names to objects. The `url` key sets the base URL; any other keys become variables.
+
+<<< @/../../../examples/guide/env-config.json
+
+Use the `env` keyword to select an environment before running requests.
+
+<<< @/../../../examples/guide/env.bel
+
+## Multi-file Workflows
+
+### `request`
+
+Runs another Bell file inline. Any variables the sub-file `export`s become available in the calling file.
+
+::: code-group
+
+<<< @/../../../examples/guide/request-main.bel [request-main.bel]
+
+<<< @/../../../examples/guide/request-sub.bel [request-sub.bel]
+
+:::
+
+### `export`
+
+Marks variables to be shared with any file that `request`s this one.
+
+<<< @/../../../examples/guide/export.bel
 
 ## Keywords as Identifiers
 
-You can use Bell keywords (like `url`, `body`, `headers`) as variables in expressions.
+Bell keywords like `url`, `body`, and `headers` can be used as variable names in expressions — for example, to log the current URL or read fields from the response body.
 
 ```bel
 log url

--- a/examples/7-securityWarnings/deleteUserProdWarning.bel
+++ b/examples/7-securityWarnings/deleteUserProdWarning.bel
@@ -1,5 +1,5 @@
 
-# @warn will prompt the user to validate before sending each request
+# warn will prompt the user to validate before sending each request
 # that contains the prodUrl variable
 prodUrl = warn "production.com"
 

--- a/examples/8-timeouts/timeouts.bel
+++ b/examples/8-timeouts/timeouts.bel
@@ -5,7 +5,7 @@ require {
 
 url urlWithLongResponseTime
 
-# use @timeout to increase or decrease the max wait time for a response
+# use timeout to increase or decrease the max wait time for a response
 # the usual response delay is 30 seconds
 # if this number is exceeded, then error
 # here we are waiting ten seconds

--- a/examples/guide/body.bel
+++ b/examples/guide/body.bel
@@ -1,0 +1,9 @@
+url "https://api.example.com/users"
+
+body {
+  "name": "Jane Doe",
+  "email": "jane@example.com",
+  "role": "admin"
+}
+
+POST

--- a/examples/guide/env-config.json
+++ b/examples/guide/env-config.json
@@ -1,0 +1,10 @@
+{
+  "dev": {
+    "url": "https://dev.api.example.com",
+    "apiKey": "dev-key-123"
+  },
+  "prod": {
+    "url": "https://api.example.com",
+    "apiKey": "prod-key-456"
+  }
+}

--- a/examples/guide/env.bel
+++ b/examples/guide/env.bel
@@ -1,0 +1,14 @@
+import "./env-config.json"
+
+# env with no argument prompts the user to choose from all available environments
+env
+
+# env with options limits the choices shown to the user
+env "dev" | "prod"
+
+# env with a single value sets the environment without prompting
+env "prod"
+
+# after env is set, the url and any env variables are available
+path "/users"
+GET

--- a/examples/guide/expect.bel
+++ b/examples/guide/expect.bel
@@ -1,0 +1,13 @@
+url "https://api.example.com/users/1"
+GET
+
+# expect asserts that an expression is truthy
+# the file exits with an error if it is not
+expect response.status === 200
+expect response.body.name === "Jane Doe"
+
+url "https://api.example.com/users"
+body { "name": "New User" }
+POST
+
+expect response.status === 201

--- a/examples/guide/export.bel
+++ b/examples/guide/export.bel
@@ -1,0 +1,15 @@
+url "https://api.example.com/login"
+
+body {
+  "username": "testuser",
+  "password": "secret"
+}
+
+POST
+
+# Save the token from the response
+token = response.body.token
+userId = response.body.userId
+
+# export makes these variables available to files that request this one
+export token, userId

--- a/examples/guide/headers.bel
+++ b/examples/guide/headers.bel
@@ -1,0 +1,15 @@
+token = "my-token"
+
+url "https://api.example.com/data"
+
+# Add individual headers
+header "Authorization" "Bearer {token}"
+header "Accept"        "application/json"
+
+# Or set all headers at once with an object
+headers {
+  "Authorization": "Bearer {token}",
+  "Accept": "application/json"
+}
+
+GET

--- a/examples/guide/http-methods.bel
+++ b/examples/guide/http-methods.bel
@@ -1,0 +1,22 @@
+url "https://api.example.com/users"
+
+# GET — retrieve a resource
+GET
+
+# POST — create a resource
+body { "name": "Jane" }
+POST
+
+# PUT — replace a resource
+path "/users/1"
+body { "name": "Jane Doe" }
+PUT
+
+# PATCH — update fields on a resource
+path "/users/1"
+body { "name": "Jane D." }
+PATCH
+
+# DELETE — remove a resource
+path "/users/1"
+DELETE

--- a/examples/guide/import.bel
+++ b/examples/guide/import.bel
@@ -1,0 +1,9 @@
+# Import a default export from a JSON file
+import requestBody from "./request-body.json"
+
+# Import named exports from a TypeScript file
+import { UserRequest, UserResponse } from "./types.ts"
+
+# Import a JSON environment config file (anonymous import)
+# This loads environment definitions (dev, prod, etc.)
+import "./env-config.json"

--- a/examples/guide/input.bel
+++ b/examples/guide/input.bel
@@ -1,0 +1,15 @@
+url "https://api.example.com/users"
+
+# input() prompts the user for a value at runtime
+id = input("Enter user ID")
+path "/{id}"
+
+GET
+
+# input() can also be used inline in body or headers
+url "https://api.example.com/posts"
+body {
+  "title": input("Post title"),
+  "body":  input("Post body")
+}
+POST

--- a/examples/guide/log.bel
+++ b/examples/guide/log.bel
@@ -1,0 +1,13 @@
+url "https://api.example.com/users/1"
+GET
+
+# Log a value or expression
+log response.status
+log response.body.name
+
+# Log a variable
+count = 42
+log count
+
+# Log the current URL
+log url

--- a/examples/guide/params.bel
+++ b/examples/guide/params.bel
@@ -1,0 +1,12 @@
+url "https://api.example.com/restaurants/search"
+
+# param adds a query parameter: ?page=2&query=Sushi&location=NY
+param "page"     2
+param "query"    "Sushi"
+param "location" "NY"
+
+# param can also use a variable directly: ?userId=<value>
+userId = "abc123"
+param userId
+
+GET

--- a/examples/guide/request-main.bel
+++ b/examples/guide/request-main.bel
@@ -1,0 +1,8 @@
+# request runs another Bell file inline
+# exported variables from that file become available here
+request "./request-sub.bel"
+
+# token is now available from the sub-file's export
+url "https://api.example.com/posts"
+header "Authorization" "Bearer {token}"
+GET

--- a/examples/guide/request-sub.bel
+++ b/examples/guide/request-sub.bel
@@ -1,0 +1,11 @@
+url "https://api.example.com/login"
+
+body {
+  "username": "testuser",
+  "password": "secret"
+}
+
+POST
+
+token = response.body.token
+export token

--- a/examples/guide/response.bel
+++ b/examples/guide/response.bel
@@ -1,0 +1,26 @@
+url "https://api.example.com/users/1"
+GET
+
+# Access the full response body
+log response.body
+
+# Reach into nested properties
+log response.body.name
+log response.body.address.city
+
+# Access the HTTP status code
+log response.status
+
+# Access response headers
+log response.headers
+
+# When multiple requests are made, index into past responses
+url "https://api.example.com/login"
+POST
+
+url "https://api.example.com/data"
+GET
+
+# response[0] is the login response, response[1] is the data response
+log response[0].status
+log response[1].body

--- a/examples/guide/url-path.bel
+++ b/examples/guide/url-path.bel
@@ -1,0 +1,8 @@
+# url sets the full base URL for the request
+url "https://api.example.com"
+
+# path appends a segment to the base URL
+# result: https://api.example.com/users/123
+path "/users/123"
+
+GET

--- a/examples/guide/validate.bel
+++ b/examples/guide/validate.bel
@@ -1,0 +1,11 @@
+import requestBody from "./request-body.json"
+import { UserRequest, UserResponse } from "./types.ts"
+
+# validate checks that a value matches a TypeScript type at runtime
+validate requestBody as UserRequest
+
+url "https://api.example.com/users"
+body requestBody
+POST
+
+validate response.body as UserResponse

--- a/examples/guide/variables.bel
+++ b/examples/guide/variables.bel
@@ -1,0 +1,9 @@
+# Assign a string to a variable
+apiKey = "my-secret-token"
+userId = 42
+
+# Use variables inside strings with {variableName}
+url "https://api.example.com/users/{userId}"
+header "Authorization" "Bearer {apiKey}"
+
+GET

--- a/examples/guide/warn.bel
+++ b/examples/guide/warn.bel
@@ -1,0 +1,12 @@
+# warn as an expression — prompts for confirmation and returns the value
+# execution stops if the user declines
+prodUrl = warn "production.example.com"
+
+url "https://{prodUrl}/users"
+GET
+
+# warn as a statement — shows a message and asks the user to confirm
+warn "You are about to delete a user. Proceed?"
+
+url "https://api.example.com/users/1"
+DELETE

--- a/packages/core/src/cli.ts
+++ b/packages/core/src/cli.ts
@@ -108,6 +108,50 @@ program
     }
   });
 
+const INIT_EXAMPLE = `\
+# Bell starter file
+# Run this with: bell run bell/example.GET.bel
+
+# Fetch a post from a public API
+url "https://jsonplaceholder.typicode.com/posts/1"
+GET
+
+# Try changing the id, or swap in your own URL:
+#
+#   id = 42
+#   url "https://jsonplaceholder.typicode.com/posts/{id}"
+#   GET
+#
+# Add headers:
+#   header "Authorization" "Bearer <token>"
+#
+# Send a POST:
+#   url "https://jsonplaceholder.typicode.com/posts"
+#   body { "title": "hello", "body": "world", "userId": 1 }
+#   POST
+`;
+
+program
+  .command('init')
+  .description('Create a bell/ folder with a starter example file')
+  .action(() => {
+    const dir = path.resolve('bell');
+    const file = path.join(dir, 'example.GET.bel');
+
+    if (fs.existsSync(dir)) {
+      console.error(chalk.red(`✖ Directory already exists: ${chalk.bold(dir)}`));
+      process.exit(1);
+    }
+
+    fs.mkdirSync(dir);
+    fs.writeFileSync(file, INIT_EXAMPLE, 'utf8');
+
+    console.log(chalk.green(`✔ Created ${chalk.bold('bell/example.GET.bel')}`));
+    console.log('');
+    console.log(`  Run it:  ${chalk.cyan('bell run bell/example.GET.bel')}`);
+    console.log(`  Or open ${chalk.bold('bell/example.GET.bel')} and make it your own.`);
+  });
+
 // Python-style: `bell -c <code>` — inline execution (handled before commander)
 const cFlagIdx = process.argv.indexOf('-c');
 if (cFlagIdx !== -1 && cFlagIdx + 1 < process.argv.length) {
@@ -127,7 +171,7 @@ if (cFlagIdx !== -1 && cFlagIdx + 1 < process.argv.length) {
   startRepl();
 } else {
   // Python-style: `bell <file.bel> [options]` — direct file invocation
-  const knownSubcommands = new Set(['run', 'convert', 'format', 'help']);
+  const knownSubcommands = new Set(['run', 'convert', 'format', 'init', 'help']);
   const firstArg = process.argv[2];
   if (firstArg && !firstArg.startsWith('-') && !knownSubcommands.has(firstArg) && firstArg.endsWith('.bel')) {
     // Rewrite argv so commander sees it as `bell run <file> [rest...]`

--- a/packages/core/src/cli.ts
+++ b/packages/core/src/cli.ts
@@ -6,6 +6,7 @@ import chalk from 'chalk';
 import { runSource } from './interpreter/run';
 import { convertPostmanToBell } from './converters/postman';
 import { formatBellFile } from './formatter/BellFormatter';
+import { startRepl } from './repl/BellRepl';
 
 const program = new Command();
 
@@ -121,6 +122,9 @@ if (cFlagIdx !== -1 && cFlagIdx + 1 < process.argv.length) {
       process.exit(1);
     }
   })();
+} else if (process.argv.length === 2) {
+  // No arguments — start the REPL
+  startRepl();
 } else {
   // Python-style: `bell <file.bel> [options]` — direct file invocation
   const knownSubcommands = new Set(['run', 'convert', 'format', 'help']);

--- a/packages/core/src/formatter/BellFormatter.ts
+++ b/packages/core/src/formatter/BellFormatter.ts
@@ -249,7 +249,7 @@ function formatRequestBuilding(rbs: RequestBuildingStatementContext): FormattedI
   if (require_) return { kind: 'require', comments: [], text: `require ${formatExpr(require_.expression())}` };
 
   const reqFile = rbs.requestStatementBuilding();
-  if (reqFile) return { kind: 'request-file', comments: [], text: `request ${formatExpr(reqFile.expression())}` };
+  if (reqFile) return { kind: 'request-file', comments: [], text: `request ${reqFile.StringLiteral().text}` };
 
   const env = rbs.envStatement();
   if (env) {

--- a/packages/core/src/grammar/BellParser.g4
+++ b/packages/core/src/grammar/BellParser.g4
@@ -176,7 +176,7 @@ requireStatement
   ;
 
 requestStatementBuilding
-  : Request LineTerminator* expression
+  : Request LineTerminator* StringLiteral
   ;
 
 envStatement

--- a/packages/core/src/interpreter/BellVisitor.ts
+++ b/packages/core/src/interpreter/BellVisitor.ts
@@ -167,7 +167,7 @@ export class BellVisitor extends AbstractParseTreeVisitor<any> implements BellPa
     this.requestConfig.data = body;
   }
 
-  private resetRequestConfig(): void {
+  resetRequestConfig(): void {
     this.requestConfig = { method: 'GET', url: '', params: {}, headers: {}, data: null };
   }
 

--- a/packages/core/src/interpreter/BellVisitor.ts
+++ b/packages/core/src/interpreter/BellVisitor.ts
@@ -349,7 +349,7 @@ export class BellVisitor extends AbstractParseTreeVisitor<any> implements BellPa
   }
 
   async visitRequestStatementBuilding(ctx: RequestStatementBuildingContext): Promise<void> {
-    const relPath = await this.visit(ctx.expression());
+    const relPath = ctx.StringLiteral().text.slice(1, -1);
     const fullPath = this.resolvePath(relPath);
     
     console.log(chalk.gray(`  Loading request file: ${fullPath}`));

--- a/packages/core/src/repl/BellRepl.ts
+++ b/packages/core/src/repl/BellRepl.ts
@@ -1,0 +1,119 @@
+import * as readline from 'readline';
+import * as path from 'path';
+import chalk from 'chalk';
+import { BellVisitor } from '../interpreter/BellVisitor';
+import { runSource } from '../interpreter/run';
+
+const VERSION = '0.0.1';
+
+const HELP_TEXT = `
+Bell REPL — keyword reference
+  url "https://..."        set the base URL
+  path "/foo"              append a path segment
+  param key "value"        add a query parameter
+  header key "value"       add a request header
+  body { ... }             set the request body
+  GET / POST / PUT / PATCH / DELETE   dispatch the request
+  log <expr>               print a value
+  expect <expr>            assert a truthy value
+  name = <expr>            assign a variable
+  import "file.json"       load an environment file
+  env "name"               select an environment
+  response.body            last response body
+  response.status          last response status code
+
+Special commands:
+  help   show this message
+  clear  reset all state (variables, response, env)
+  exit   quit the REPL
+`.trim();
+
+export async function startRepl(): Promise<void> {
+  const rl = readline.createInterface({
+    input: process.stdin,
+    output: process.stdout,
+    terminal: true,
+    prompt: '>>> ',
+  });
+
+  console.log(chalk.bold(`Bell ${VERSION}`) + chalk.gray(`  (type 'exit' or Ctrl+D to quit)`));
+
+  let visitor = new BellVisitor(path.join(process.cwd(), '<repl>'));
+  let buffer = '';
+  let braceDepth = 0;
+  let bracketDepth = 0;
+
+  const isComplete = () => braceDepth === 0 && bracketDepth === 0 && buffer.trim().length > 0;
+
+  const resetPrompt = () => {
+    buffer = '';
+    braceDepth = 0;
+    bracketDepth = 0;
+    rl.setPrompt('>>> ');
+    rl.prompt();
+  };
+
+  rl.prompt();
+
+  rl.on('line', async (line: string) => {
+    // Handle special commands on empty buffer
+    if (buffer === '') {
+      const trimmed = line.trim();
+      if (trimmed === 'exit' || trimmed === 'quit') {
+        rl.close();
+        process.exit(0);
+      }
+      if (trimmed === 'help') {
+        console.log(HELP_TEXT);
+        rl.prompt();
+        return;
+      }
+      if (trimmed === 'clear') {
+        visitor = new BellVisitor(path.join(process.cwd(), '<repl>'));
+        console.log(chalk.gray('  State cleared.'));
+        rl.prompt();
+        return;
+      }
+    }
+
+    // Accumulate input
+    buffer += (buffer ? '\n' : '') + line;
+
+    // Track brace/bracket depth for multi-line detection
+    for (const ch of line) {
+      if (ch === '{') braceDepth++;
+      else if (ch === '}') braceDepth--;
+      else if (ch === '[') bracketDepth++;
+      else if (ch === ']') bracketDepth--;
+    }
+
+    if (!isComplete()) {
+      rl.setPrompt('... ');
+      rl.prompt();
+      return;
+    }
+
+    // Execute the complete input
+    const source = buffer;
+    buffer = '';
+    braceDepth = 0;
+    bracketDepth = 0;
+
+    rl.pause();
+    try {
+      await runSource(source, path.join(process.cwd(), '<repl>'), { visitor });
+      visitor.resetRequestConfig();
+    } catch (err: any) {
+      console.error(chalk.red(`  ✖ ${err.message}`));
+    } finally {
+      rl.resume();
+      rl.setPrompt('>>> ');
+      rl.prompt();
+    }
+  });
+
+  rl.on('close', () => {
+    console.log('');
+    process.exit(0);
+  });
+}

--- a/packages/core/src/repl/BellRepl.ts
+++ b/packages/core/src/repl/BellRepl.ts
@@ -33,7 +33,7 @@ export async function startRepl(): Promise<void> {
     input: process.stdin,
     output: process.stdout,
     terminal: true,
-    prompt: '>>> ',
+    prompt: 'bell> ',
   });
 
   console.log(chalk.bold(`Bell ${VERSION}`) + chalk.gray(`  (type 'exit' or Ctrl+D to quit)`));
@@ -49,7 +49,7 @@ export async function startRepl(): Promise<void> {
     buffer = '';
     braceDepth = 0;
     bracketDepth = 0;
-    rl.setPrompt('>>> ');
+    rl.setPrompt('bell> ');
     rl.prompt();
   };
 
@@ -107,7 +107,7 @@ export async function startRepl(): Promise<void> {
       console.error(chalk.red(`  ✖ ${err.message}`));
     } finally {
       rl.resume();
-      rl.setPrompt('>>> ');
+      rl.setPrompt('bell> ');
       rl.prompt();
     }
   });


### PR DESCRIPTION
Implements Phase 3 of the python-style CLI plan. Running `bell` with no
arguments starts an interactive REPL backed by a persistent BellVisitor,
so variables and response state carry across prompts. requestConfig is
reset after each dispatched request. Multi-line constructs (unclosed
braces/brackets) accumulate behind a `...` continuation prompt.
Special commands: exit/quit, clear, help.

https://claude.ai/code/session_01XvrWD6wjf2ifiLmH3qG15z