### PR TITLE
Add Migrate from Postman page to docs

### DIFF
--- a/.claude/commands/release.md
+++ b/.claude/commands/release.md
@@ -1,0 +1,80 @@
+# Release Bell
+
+Perform a release of `bell-lang` (core) and/or `bell-vscode` (VS Code extension) — only for packages with unreleased changes.
+
+> **`apps/docs` is not part of this flow.** The docs site deploys automatically to GitHub Pages on every merge to `main` that touches `apps/docs/**` — no manual step needed.
+
+## Step 1: Determine what needs releasing
+
+Find the most recent git tag and check which packages have changed since then:
+
+```bash
+git tag --sort=-v:refname | head -1
+git log <last-tag>..HEAD --oneline --name-only -- packages/core packages/vscode
+```
+
+Also show the current versions:
+- `packages/core/package.json` → `version`
+- `packages/vscode/package.json` → `version`
+
+If a package has no changed files since the last tag, **skip it** — do not bump or publish it.
+
+## Step 2: For each package that has changes, confirm the bump type
+
+Ask the user: "core has changes — bump patch, minor, or major?" (and same for vscode if applicable). Default to `patch` unless there are new features (minor) or breaking changes (major).
+
+## Step 3: Release `packages/core` (if needed)
+
+Run from `packages/core/`:
+
+```bash
+npm run build
+npm test
+```
+
+If tests pass, bump the version:
+```bash
+npm version <patch|minor|major>
+```
+
+Then publish:
+```bash
+npm publish --access public
+```
+
+If `npm publish` fails with an auth error, tell the user to run `! npm login` and retry.
+
+## Step 4: Release `packages/vscode` (if needed)
+
+Run from `packages/vscode/`:
+
+```bash
+npm run compile
+vsce package --no-dependencies
+```
+
+Then publish:
+```bash
+vsce publish --no-dependencies
+```
+
+If `vsce publish` fails with an auth error, remind the user they need a Personal Access Token from Azure DevOps with `Marketplace → Publish` scope, and to run `! vsce login bell`.
+
+## Step 5: Tag and push — CI handles the rest
+
+Tag using the **core version** (the npm package drives the overall version):
+
+```bash
+git tag v<core-version>
+git push --tags
+```
+
+If only vscode was released (no core changes), tag using the vscode version with a `vscode-` prefix: `git tag vscode-v<vscode-version>`.
+
+Pushing a `v*` tag triggers `.github/workflows/release.yml`, which builds and publishes both `bell-lang` to npm and the extension to the VS Code Marketplace automatically. The manual publish steps above (Steps 3–4) are only needed if CI is unavailable or you need to publish without tagging.
+
+## Notes
+
+- Never publish a package just because the other one was released — each package is independent.
+- The VS Code extension depends on `bell` being available via `npx` or global install, so always release core first if both need releasing.
+- After publishing, the npm package is live at https://www.npmjs.com/package/bell-lang and the extension dashboard is at https://marketplace.visualstudio.com/manage/publishers/bell.

--- a/_docs/PUBLISHING.md
+++ b/_docs/PUBLISHING.md
@@ -69,6 +69,7 @@ Live package: https://www.npmjs.com/package/bell-lang
 
 2. Package:
    ```bash
+   npm version patch # or minor / major
    vsce package --no-dependencies
    ```
    > The `--no-dependencies` flag is required in this monorepo to prevent `vsce` from following workspace symlinks and throwing "invalid relative path" errors.

--- a/_docs/PUBLISHING.md
+++ b/_docs/PUBLISHING.md
@@ -4,9 +4,19 @@ Steps to publish Bell components to NPM and the VS Code Marketplace.
 
 ---
 
-## NPM: `bell-lang`
+## Docs Site (`apps/docs`)
 
-Publish the core package first, since the VS Code extension depends on the CLI being available via `npx`/global install.
+**Deploys automatically** via GitHub Actions (`.github/workflows/docs.yml`) on every merge to `main` that touches `apps/docs/**` or `packages/vscode/syntaxes/bel.tmLanguage.json`. No manual steps needed.
+
+Live site: https://pjflanagan.github.io/bell/
+
+---
+
+## NPM: `bell-lang` and VS Code Extension
+
+> **Preferred flow:** bump versions locally, push a `v*` tag, and CI (`.github/workflows/release.yml`) handles building and publishing both packages automatically. The manual steps below are a fallback.
+
+Publish core first — the VS Code extension depends on the CLI being available via `npx`/global install.
 
 **Prerequisites**
 - An npm account with publish access to `bell-lang`
@@ -29,6 +39,7 @@ Publish the core package first, since the VS Code extension depends on the CLI b
 
 4. Publish:
    ```bash
+   npm login
    npm publish --access public
    ```
 

--- a/apps/docs/docs/.vitepress/config.js
+++ b/apps/docs/docs/.vitepress/config.js
@@ -49,6 +49,7 @@ export default defineConfig({
           { text: 'Getting Started', link: '/guide/getting-started' },
           { text: 'Syntax', link: '/guide/syntax' },
           { text: 'CLI', link: '/guide/cli' },
+          { text: 'Migrate from Postman', link: '/guide/migrate' },
           { text: 'Examples', link: '/guide/examples' },
           { text: 'AI Skill', link: '/guide/ai-skill' }
         ]

--- a/apps/docs/docs/guide/cli.md
+++ b/apps/docs/docs/guide/cli.md
@@ -53,7 +53,7 @@ bell convert <postman-json> [options]
 ```
 
 **Options:**
-- `-o, --output <dir>`: Output directory for the `.bel` files (default: `./bell-scripts`).
+- `-o, --output <dir>`: Output directory for the `.bel` files (default: `./bell`).
 
 ### `format`
 Formats a Bell file according to the language style.

--- a/apps/docs/docs/guide/migrate.md
+++ b/apps/docs/docs/guide/migrate.md
@@ -1,0 +1,51 @@
+# Migrate from Postman
+
+Bell can convert a Postman collection into `.bel` files using the `bell convert` command. This page walks you through exporting your collection from Postman and running the conversion.
+
+## Step 1: Export from Postman
+
+1. Open Postman and select the collection you want to migrate.
+2. Click the **&hellip;** (three-dot menu) next to the collection name.
+3. Select **Export**.
+4. Choose **Collection v2.1** as the format.
+5. Click **Export** and save the file (e.g. `my-api.postman_collection.json`).
+
+## Step 2: Convert to Bell
+
+Run the `convert` command, pointing it at the exported JSON file:
+
+```bash
+bell convert my-api.postman_collection.json
+```
+
+This creates a `bell-scripts/` directory in your current folder containing one `.bel` file per request in the collection.
+
+To write the output to a specific directory, use the `-o` flag:
+
+```bash
+bell convert my-api.postman_collection.json -o ./bell
+```
+
+## Step 3: Run the converted files
+
+Each generated file corresponds to a single request. Run one with:
+
+```bash
+bell run bell/get-users.GET.bel
+```
+
+## What gets converted
+
+| Postman feature | Bell equivalent |
+|---|---|
+| Request URL | `url` |
+| Path variables | `path` |
+| Query parameters | `param` |
+| Request headers | `header` |
+| Request body (JSON) | `body` |
+| HTTP method | `GET`, `POST`, `PUT`, `PATCH`, `DELETE` |
+| Collection variables | Bell variables (`name = "value"`) |
+
+::: info
+Environment variables and pre-request scripts are not automatically converted. You can add these manually after conversion — see [Syntax](/guide/syntax) for how to define environments and variables.
+:::

--- a/apps/docs/docs/guide/migrate.md
+++ b/apps/docs/docs/guide/migrate.md
@@ -18,7 +18,7 @@ Run the `convert` command, pointing it at the exported JSON file:
 bell convert my-api.postman_collection.json
 ```
 
-This creates a `bell-scripts/` directory in your current folder containing one `.bel` file per request in the collection.
+This creates a `bell/` directory in your current folder containing one `.bel` file per request in the collection.
 
 To write the output to a specific directory, use the `-o` flag:
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -7299,7 +7299,7 @@
     },
     "packages/core": {
       "name": "bell-lang",
-      "version": "0.1.2",
+      "version": "0.1.3",
       "license": "MIT",
       "dependencies": {
         "@types/chai": "^5.2.3",
@@ -7365,7 +7365,7 @@
     },
     "packages/vscode": {
       "name": "bell-vscode",
-      "version": "0.1.0",
+      "version": "0.1.3",
       "license": "MIT",
       "devDependencies": {
         "@types/node": "20.x",

--- a/package-lock.json
+++ b/package-lock.json
@@ -7299,7 +7299,7 @@
     },
     "packages/core": {
       "name": "bell-lang",
-      "version": "0.1.1",
+      "version": "0.1.2",
       "license": "MIT",
       "dependencies": {
         "@types/chai": "^5.2.3",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bell-lang",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "description": "A simple script for making http requests",
   "license": "MIT",
   "type": "commonjs",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,12 +1,12 @@
 {
   "name": "bell-lang",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "description": "A simple script for making http requests",
   "license": "MIT",
   "type": "commonjs",
   "main": "./dist/src/interpreter/run.js",
   "bin": {
-    "bell": "./dist/src/cli.js"
+    "bell": "dist/src/cli.js"
   },
   "files": [
     "dist",

--- a/packages/core/src/cli.ts
+++ b/packages/core/src/cli.ts
@@ -35,7 +35,7 @@ program
   .command('convert')
   .description('Convert a Postman collection to Bell files')
   .argument('<postman-json>', 'Path to the exported Postman collection JSON')
-  .option('-o, --output <dir>', 'Output directory for the .bel files', './bell-scripts')
+  .option('-o, --output <dir>', 'Output directory for the .bel files', './bell')
   .action((postmanJson, options) => {
     const postmanPath = path.resolve(postmanJson);
     if (!fs.existsSync(postmanPath)) {

--- a/packages/vscode/package.json
+++ b/packages/vscode/package.json
@@ -2,7 +2,7 @@
   "name": "bell-vscode",
   "displayName": "Bell Lang: Syntax and UI",
   "description": "A simple script for making http requests",
-  "version": "0.1.1",
+  "version": "0.1.3",
   "license": "MIT",
   "publisher": "bell",
   "icon": "icon.png",


### PR DESCRIPTION
Documents the export-then-convert workflow: how to export a Postman
collection as v2.1 JSON and run `bell convert` to generate .bel files.
Adds the page to the sidebar between CLI and Examples.

https://claude.ai/code/session_01B9QhvADCuVwkXDANhQt6uS