### PR TITLE
Add `bell openapi` command to convert OpenAPI 3.x specs to Bell files

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -23,7 +23,8 @@ npm test
 npx ts-node ./src/main.ts           # hardcoded example runner
 bell run <file.bel>                  # via CLI (after build)
 bell run <file.bel> -e <env>         # with environment selection
-bell convert <postman.json> -o ./out # convert Postman collection
+bell postman <collection.json> -o ./out # convert Postman collection
+bell convert <postman.json> -o ./out    # alias for bell postman (deprecated)
 bell openapi <spec.json> -o ./out    # convert OpenAPI 3.x spec (JSON or YAML)
 
 # Regenerate ANTLR grammar (after editing .g4 files)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -24,6 +24,7 @@ npx ts-node ./src/main.ts           # hardcoded example runner
 bell run <file.bel>                  # via CLI (after build)
 bell run <file.bel> -e <env>         # with environment selection
 bell convert <postman.json> -o ./out # convert Postman collection
+bell openapi <spec.json> -o ./out    # convert OpenAPI 3.x spec (JSON or YAML)
 
 # Regenerate ANTLR grammar (after editing .g4 files)
 npm run build-lexer   # regenerates BellLexer.ts from BellLexer.g4

--- a/README.md
+++ b/README.md
@@ -180,6 +180,8 @@ log `Status: {response.status}`
 | `bell format <file.bel> --stdout` | Print formatted output to stdout |
 | `bell convert <postman.json>` | Convert a Postman collection to Bell files |
 | `bell convert <postman.json> -o <dir>` | Convert and write to a specific directory |
+| `bell openapi <spec.json>` | Convert an OpenAPI 3.x spec (JSON or YAML) to Bell files |
+| `bell openapi <spec.yaml> -o <dir>` | Convert an OpenAPI spec and write to a specific directory |
 | `bell -c "<code>"` | Execute Bell code inline (use `\n` for newlines) |
 | `bell` | Start the interactive REPL |
 

--- a/README.md
+++ b/README.md
@@ -178,8 +178,8 @@ log `Status: {response.status}`
 | `bell format <file.bel>` | Format a Bell file in-place |
 | `bell format <file.bel> --check` | Exit with code 1 if file would be reformatted |
 | `bell format <file.bel> --stdout` | Print formatted output to stdout |
-| `bell convert <postman.json>` | Convert a Postman collection to Bell files |
-| `bell convert <postman.json> -o <dir>` | Convert and write to a specific directory |
+| `bell postman <collection.json>` | Convert a Postman collection to Bell files |
+| `bell postman <collection.json> -o <dir>` | Convert and write to a specific directory |
 | `bell openapi <spec.json>` | Convert an OpenAPI 3.x spec (JSON or YAML) to Bell files |
 | `bell openapi <spec.yaml> -o <dir>` | Convert an OpenAPI spec and write to a specific directory |
 | `bell -c "<code>"` | Execute Bell code inline (use `\n` for newlines) |

--- a/_docs/plans/todo/more-converters.md
+++ b/_docs/plans/todo/more-converters.md
@@ -1,0 +1,212 @@
+# More Converters
+
+Bell currently converts from Postman and OpenAPI. Each new source format follows the same pattern: one subcommand (`bell <format>`), one converter module in `src/converters/`, fixture-based tests, and a section on the `/guide/migrate` docs page.
+
+---
+
+## Formats to support
+
+### `bell curl` — convert a curl command
+
+**Why:** curl commands appear everywhere — API docs, Stack Overflow, GitHub READMEs, terminal history. This is the fastest path from "I found an example" to a runnable Bell file.
+
+**Input:** A curl command string (passed as an argument or piped from stdin).
+
+```bash
+bell curl 'curl -X POST https://api.example.com/users \
+  -H "Authorization: Bearer TOKEN" \
+  -H "Content-Type: application/json" \
+  -d "{\"name\":\"alice\"}"'
+
+# or pipe it
+pbpaste | bell curl
+```
+
+**What to parse:**
+- `-X METHOD` or implied GET
+- URL (positional argument)
+- `-H "Key: Value"` headers
+- `-d`, `--data`, `--data-raw`, `--data-binary` body (detect JSON vs raw)
+- `-u user:pass` → Basic auth header
+- `--url` as alternative to positional URL
+- Multiple `-H` flags
+
+**Output:** A single `.bel` file (stdout by default, or `-o file.bel`).
+
+**Notes:** No subdirectory structure — curl is always one request. Consider a `--stdout` mode that prints to stdout instead of writing a file, so it can be used inline.
+
+---
+
+### `bell har` — convert a browser HAR export
+
+**Why:** HAR (HTTP Archive) is the format exported from Chrome/Firefox DevTools → Network tab → "Save all as HAR". It captures real traffic, including cookies, timing, and full request/response pairs. Useful for turning "I saw this request in DevTools" into a reproducible Bell file.
+
+**Input:** A `.har` JSON file.
+
+```bash
+bell har network-export.har -o ./bell
+```
+
+**Structure of a HAR file:**
+```json
+{
+  "log": {
+    "entries": [
+      {
+        "request": {
+          "method": "POST",
+          "url": "https://api.example.com/users",
+          "headers": [{ "name": "Authorization", "value": "Bearer ..." }],
+          "postData": { "mimeType": "application/json", "text": "{...}" },
+          "queryString": [{ "name": "page", "value": "1" }]
+        },
+        "response": {
+          "status": 200
+        }
+      }
+    ]
+  }
+}
+```
+
+**What to handle:**
+- Filter out noise: browser internals (`chrome-extension://`), static assets (images, fonts, CSS/JS by MIME type), preflight OPTIONS
+- Merge duplicate entries for the same endpoint
+- Strip or redact `Cookie` and `Set-Cookie` headers by default (add `--include-cookies` flag)
+- Use the actual response status code in the `expect` assertion
+- Group by path prefix into subdirectories
+
+**Notes:** HAR files can be very large (100s of entries). A `--filter <pattern>` flag to match URLs by substring or regex would be useful. Consider a `--dedupe` flag that keeps only the last request per unique `method + path`.
+
+---
+
+### `bell insomnia` — convert an Insomnia collection
+
+**Why:** Insomnia is a popular alternative to Postman with a similar feature set. Its export format is straightforward JSON.
+
+**Input:** An Insomnia v4 export JSON.
+
+```bash
+bell insomnia Insomnia_export.json -o ./bell
+```
+
+**Insomnia export structure:**
+```json
+{
+  "__export_format": 4,
+  "resources": [
+    { "_type": "request", "name": "Get Users", "method": "GET", "url": "..." },
+    { "_type": "request_group", "name": "Users", "parentId": "..." }
+  ]
+}
+```
+
+**What to handle:**
+- `_type: "request"` → one `.bel` file
+- `_type: "request_group"` → subdirectory (reconstruct tree via `parentId`)
+- Insomnia `{{ variable }}` syntax → Bell `{variable}`
+- `body.mimeType === "application/json"` → `body { ... }`
+- `authentication` block:
+  - `type: "bearer"` → `header "Authorization" "Bearer {token}"`
+  - `type: "basic"` → `header "Authorization" "Basic ..."`
+  - `type: "apikey"` → `header "{key}" "{value}"`
+- `environments` → `env.json`
+
+---
+
+### `bell bruno` — convert a Bruno collection
+
+**Why:** Bruno is a growing open-source alternative to Postman/Insomnia that stores collections as plain text files (`.bru` format) in a git-friendly way. Users migrating to Bell from Bruno will want this.
+
+**Input:** A Bruno collection directory or a single `.bru` file.
+
+```bash
+bell bruno ./my-collection/ -o ./bell
+bell bruno request.bru -o request.GET.bel
+```
+
+**Bruno `.bru` format** (plain text, not JSON):
+```
+meta {
+  name: Get Users
+  type: http
+}
+
+get {
+  url: https://api.example.com/users
+}
+
+headers {
+  Authorization: Bearer {{token}}
+}
+
+body:json {
+  {
+    "name": "alice"
+  }
+}
+```
+
+**What to handle:**
+- Parse the block-based `.bru` syntax (each block is `blockName { ... }`)
+- Recurse through directories, preserving folder structure
+- `{{variable}}` → `{variable}`
+- `body:json`, `body:text`, `body:form-urlencoded`
+- `auth:bearer`, `auth:basic`, `auth:apikey`
+
+**Notes:** The `.bru` parser will need to be written from scratch (it's a custom format). A simple line-by-line state machine should be sufficient — it's not deeply nested.
+
+---
+
+### `bell http` — convert a `.http` / REST Client file
+
+**Why:** The [REST Client VS Code extension](https://marketplace.visualstudio.com/items?itemName=humao.rest-client) uses `.http` files that many developers already have in their repos. These files are a natural gateway into Bell.
+
+**Input:** A `.http` or `.rest` file.
+
+```bash
+bell http requests.http -o ./bell
+```
+
+**`.http` format:**
+```http
+### Get a user
+GET https://api.example.com/users/1
+Authorization: Bearer {{token}}
+
+###
+
+### Create a user
+POST https://api.example.com/users
+Content-Type: application/json
+
+{
+  "name": "alice"
+}
+```
+
+**What to handle:**
+- `###` as the request separator (with optional name as comment)
+- First line of each block: `METHOD URL`
+- Headers: `Key: Value` lines before the blank line
+- Body: content after the blank line
+- `{{variable}}` → `{variable}`
+- `@variable = value` declarations at the top of the file → Bell variables
+- Generate one `.bel` file per `###` block
+
+---
+
+## Shared implementation notes
+
+- All converters live in `src/converters/<format>.ts` and are wired up in `cli.ts`
+- Fixture-based tests follow the same pattern as the Postman and OpenAPI converters: `test/<format>/` with `input.*` and `expected/` files
+- Each format gets a section on the `/guide/migrate` docs page
+- `sanitizeName` (camelCase → snake_case, non-alnum → `_`) is shared — put it in `src/converters/utils.ts` when adding the second new converter
+
+## Priority order
+
+1. **`bell curl`** — highest leverage, no file to export, works from clipboard
+2. **`bell har`** — captures real traffic; unique angle vs other converters
+3. **`bell insomnia`** — large user base, straightforward format
+4. **`bell http`** — existing REST Client users are natural Bell adopters
+5. **`bell bruno`** — smaller current user base, custom parser needed

--- a/apps/docs/docs/.vitepress/config.js
+++ b/apps/docs/docs/.vitepress/config.js
@@ -49,7 +49,7 @@ export default defineConfig({
           { text: 'Getting Started', link: '/guide/getting-started' },
           { text: 'Syntax', link: '/guide/syntax' },
           { text: 'CLI', link: '/guide/cli' },
-          { text: 'Migrate from Postman', link: '/guide/migrate' },
+          { text: 'Converting to Bell', link: '/guide/migrate' },
           { text: 'Examples', link: '/guide/examples' },
           { text: 'AI Skill', link: '/guide/ai-skill' }
         ]

--- a/apps/docs/docs/guide/migrate.md
+++ b/apps/docs/docs/guide/migrate.md
@@ -1,51 +1,141 @@
-# Migrate from Postman
+# Converting to Bell
 
-Bell can convert a Postman collection into `.bel` files using the `bell convert` command. This page walks you through exporting your collection from Postman and running the conversion.
+Bell can import your existing API definitions from **Postman collections** and **OpenAPI specs**, converting them into runnable `.bel` files.
 
-## Step 1: Export from Postman
+---
 
-1. Open Postman and select the collection you want to migrate.
-2. Click the **&hellip;** (three-dot menu) next to the collection name.
-3. Select **Export**.
-4. Choose **Collection v2.1** as the format.
-5. Click **Export** and save the file (e.g. `my-api.postman_collection.json`).
+## From Postman
 
-## Step 2: Convert to Bell
+### Step 1: Export your collection
 
-Run the `convert` command, pointing it at the exported JSON file:
+1. Open Postman and find the collection you want to convert.
+2. Click the **&hellip;** menu next to the collection name.
+3. Select **Export** → **Collection v2.1**.
+4. Save the JSON file (e.g. `my-api.postman_collection.json`).
 
-```bash
-bell convert my-api.postman_collection.json
-```
-
-This creates a `bell/` directory in your current folder containing one `.bel` file per request in the collection.
-
-To write the output to a specific directory, use the `-o` flag:
+### Step 2: Run `bell postman`
 
 ```bash
-bell convert my-api.postman_collection.json -o ./bell
+bell postman my-api.postman_collection.json
 ```
 
-## Step 3: Run the converted files
+This creates a `bell/` folder with one `.bel` file per request. Folders in the collection become subdirectories:
 
-Each generated file corresponds to a single request. Run one with:
+```
+bell/
+  users/
+    get_users.GET.bel
+    create_user.POST.bel
+  auth/
+    login.POST.bel
+```
+
+Use `-o` to write to a different directory:
 
 ```bash
-bell run bell/get-users.GET.bel
+bell postman my-api.postman_collection.json -o ./api
 ```
 
-## What gets converted
+### What gets converted
 
-| Postman feature | Bell equivalent |
+| Postman | Bell |
 |---|---|
 | Request URL | `url` |
-| Path variables | `path` |
+| Path variables | `{variable}` interpolation |
 | Query parameters | `param` |
-| Request headers | `header` |
-| Request body (JSON) | `body` |
+| Request headers | `headers { ... }` |
+| Request body (JSON) | `body { ... }` |
 | HTTP method | `GET`, `POST`, `PUT`, `PATCH`, `DELETE` |
-| Collection variables | Bell variables (`name = "value"`) |
+| Collection folders | Subdirectories |
+| `{{variables}}` syntax | `{variables}` syntax |
 
 ::: info
-Environment variables and pre-request scripts are not automatically converted. You can add these manually after conversion — see [Syntax](/guide/syntax) for how to define environments and variables.
+Environment variables and pre-request scripts are not converted automatically. Add them manually after conversion — see [Syntax](/guide/syntax) for how to define environments and variables.
+:::
+
+---
+
+## From OpenAPI
+
+### Step 1: Have your spec ready
+
+Bell accepts **OpenAPI 3.x** specs in JSON or YAML format. Swagger 2.0 is not supported.
+
+### Step 2: Run `bell openapi`
+
+```bash
+bell openapi my-api.openapi.json
+```
+
+YAML specs work the same way:
+
+```bash
+bell openapi my-api.yaml -o ./bell
+```
+
+Bell reads the spec and generates one `.bel` file per operation, grouped by tag (falling back to the first path segment). If the spec defines `servers`, Bell also generates an `env.json`:
+
+```
+bell/
+  env.json
+  users/
+    list_users.GET.bel
+    create_user.POST.bel
+    get_user.GET.bel
+  posts/
+    list_posts.GET.bel
+```
+
+### What gets converted
+
+| OpenAPI | Bell |
+|---|---|
+| `servers[].url` | `env.json` + `import` + `path` |
+| `operationId` | File name (e.g. `list_users.GET.bel`) |
+| `tags[0]` | Subdirectory name |
+| Path parameters `{id}` | Bell variable declaration + `{id}` in path |
+| Query parameters | `param` |
+| Header parameters | `header` |
+| `requestBody` schema | `body { ... }` with example values |
+| Security schemes | Commented `# header "Authorization" ...` |
+| 2xx response code | `expect response.status === N` |
+
+### Generated files
+
+Given a spec with two servers and a `GET /users/{userId}` operation tagged `Users`:
+
+::: code-group
+
+```json [env.json]
+{
+  "production": {
+    "url": "https://api.example.com"
+  },
+  "staging": {
+    "url": "https://staging.api.example.com"
+  }
+}
+```
+
+```bel [users/get_user.GET.bel]
+### Get a user
+
+import "../env.json"
+env "production" | "staging"
+
+userId = "example"
+
+path "/users/{userId}"
+
+GET
+
+expect response.status === 200
+```
+
+:::
+
+Running `bell run users/get_user.GET.bel` will prompt you to choose an environment, then make the request against the corresponding base URL.
+
+::: info
+After conversion, review each file and replace placeholder values (`"example"`, `"YOUR_TOKEN"`, etc.) with real data. See [Syntax](/guide/syntax) for authentication patterns and environment setup.
 :::

--- a/package-lock.json
+++ b/package-lock.json
@@ -2253,6 +2253,13 @@
         "pretty-format": "^29.0.0"
       }
     },
+    "node_modules/@types/js-yaml": {
+      "version": "4.0.9",
+      "resolved": "https://registry.npmjs.org/@types/js-yaml/-/js-yaml-4.0.9.tgz",
+      "integrity": "sha512-k4MGaQl5TGo/iipqb2UDG2UwjXziSWkh0uysQelTlJpX1qGlpUZYm8PnO4DxG1qBomtJUdYJ6qR6xdIah10JLg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@types/linkify-it": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/@types/linkify-it/-/linkify-it-5.0.0.tgz",
@@ -7299,7 +7306,7 @@
     },
     "packages/core": {
       "name": "bell-lang",
-      "version": "0.1.3",
+      "version": "0.1.4",
       "license": "MIT",
       "dependencies": {
         "@types/chai": "^5.2.3",
@@ -7313,6 +7320,7 @@
         "chalk": "4",
         "commander": "^14.0.3",
         "inquirer": "^8.2.7",
+        "js-yaml": "^4.1.1",
         "mocha": "^11.7.5",
         "sinon": "^21.0.3",
         "zod": "^4.3.6"
@@ -7322,6 +7330,7 @@
       },
       "devDependencies": {
         "@types/jest": "^29.5.11",
+        "@types/js-yaml": "^4.0.9",
         "@types/node": "^20.19.39",
         "antlr4ts-cli": "^0.5.0-alpha.4",
         "jest": "^29.7.0",
@@ -7329,6 +7338,12 @@
         "ts-node": "^10.9.2",
         "typescript": "^5.0.0"
       }
+    },
+    "packages/core/node_modules/argparse": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
+      "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
+      "license": "Python-2.0"
     },
     "packages/core/node_modules/assertion-error": {
       "version": "1.1.0",
@@ -7355,6 +7370,18 @@
         "node": ">=4"
       }
     },
+    "packages/core/node_modules/js-yaml": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.1.tgz",
+      "integrity": "sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==",
+      "license": "MIT",
+      "dependencies": {
+        "argparse": "^2.0.1"
+      },
+      "bin": {
+        "js-yaml": "bin/js-yaml.js"
+      }
+    },
     "packages/core/node_modules/type-detect": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-4.1.0.tgz",
@@ -7365,7 +7392,7 @@
     },
     "packages/vscode": {
       "name": "bell-vscode",
-      "version": "0.1.3",
+      "version": "0.1.4",
       "license": "MIT",
       "devDependencies": {
         "@types/node": "20.x",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -23,6 +23,7 @@
   },
   "devDependencies": {
     "@types/jest": "^29.5.11",
+    "@types/js-yaml": "^4.0.9",
     "@types/node": "^20.19.39",
     "antlr4ts-cli": "^0.5.0-alpha.4",
     "jest": "^29.7.0",
@@ -42,6 +43,7 @@
     "chalk": "4",
     "commander": "^14.0.3",
     "inquirer": "^8.2.7",
+    "js-yaml": "^4.1.1",
     "mocha": "^11.7.5",
     "sinon": "^21.0.3",
     "zod": "^4.3.6"

--- a/packages/core/src/cli.ts
+++ b/packages/core/src/cli.ts
@@ -33,30 +33,37 @@ program
   .version(require('../../package.json').version)
   .option('-c <code>', 'Execute Bell code directly (use \\n for newlines)');
 
+function runPostmanConvert(postmanJson: string, options: { output: string }) {
+  const postmanPath = path.resolve(postmanJson);
+  if (!fs.existsSync(postmanPath)) {
+    console.error(chalk.red(`Error: Postman collection file not found: ${postmanPath}`));
+    process.exit(1);
+  }
+
+  try {
+    console.log(chalk.blue(`🔄 Converting Postman collection: ${chalk.bold(path.basename(postmanPath))}...`));
+    convertPostmanToBell(postmanPath, path.resolve(options.output));
+    console.log(chalk.green(`\n✔ Conversion complete! Files saved to: ${chalk.bold(options.output)}`));
+  } catch (err: any) {
+    console.error(chalk.red(`\n✖ Error during conversion:`));
+    console.error(chalk.red(err.message));
+    process.exit(1);
+  }
+}
+
 program
-  .command('convert')
+  .command('postman')
   .description('Convert a Postman collection to Bell files')
   .argument('<postman-json>', 'Path to the exported Postman collection JSON')
   .option('-o, --output <dir>', 'Output directory for the .bel files', './bell')
-  .action((postmanJson, options) => {
-    const postmanPath = path.resolve(postmanJson);
-    if (!fs.existsSync(postmanPath)) {
-      console.error(chalk.red(`Error: Postman collection file not found: ${postmanPath}`));
-      process.exit(1);
-    }
+  .action(runPostmanConvert);
 
-    try {
-      console.log(chalk.blue(`🔄 Converting Postman collection: ${chalk.bold(path.basename(postmanPath))}...`));
-      convertPostmanToBell(postmanPath, path.resolve(options.output));
-      console.log(chalk.green(`
-✔ Conversion complete! Files saved to: ${chalk.bold(options.output)}`));
-    } catch (err: any) {
-      console.error(chalk.red(`
-✖ Error during conversion:`));
-      console.error(chalk.red(err.message));
-      process.exit(1);
-    }
-  });
+// Hidden alias for backward compatibility
+program
+  .command('convert', { hidden: true })
+  .argument('<postman-json>')
+  .option('-o, --output <dir>', '', './bell')
+  .action(runPostmanConvert);
 
 program
   .command('openapi')
@@ -284,7 +291,7 @@ if (cFlagIdx !== -1 && cFlagIdx + 1 < process.argv.length) {
   startRepl();
 } else {
   // Python-style: `bell <file.bel> [options]` — direct file invocation
-  const knownSubcommands = new Set(['run', 'convert', 'openapi', 'format', 'init', 'skill', 'help']);
+  const knownSubcommands = new Set(['run', 'postman', 'convert', 'openapi', 'format', 'init', 'skill', 'help']);
   const firstArg = process.argv[2];
   if (firstArg && !firstArg.startsWith('-') && !knownSubcommands.has(firstArg) && firstArg.endsWith('.bel')) {
     // Rewrite argv so commander sees it as `bell run <file> [rest...]`

--- a/packages/core/src/cli.ts
+++ b/packages/core/src/cli.ts
@@ -18,6 +18,7 @@ import * as path from 'path';
 import chalk from 'chalk';
 import { runSource } from './interpreter/run';
 import { convertPostmanToBell } from './converters/postman';
+import { convertOpenAPIToBell } from './converters/openapi';
 import { formatBellFile } from './formatter/BellFormatter';
 import { startRepl } from './repl/BellRepl';
 import { BELL_SKILL } from './skill/bellSkill';
@@ -52,6 +53,29 @@ program
     } catch (err: any) {
       console.error(chalk.red(`
 ✖ Error during conversion:`));
+      console.error(chalk.red(err.message));
+      process.exit(1);
+    }
+  });
+
+program
+  .command('openapi')
+  .description('Convert an OpenAPI 3.x spec (JSON or YAML) to Bell files')
+  .argument('<openapi-file>', 'Path to the OpenAPI spec file (.json, .yaml, or .yml)')
+  .option('-o, --output <dir>', 'Output directory for the .bel files', './bell')
+  .action((openApiFile, options) => {
+    const openApiPath = path.resolve(openApiFile);
+    if (!fs.existsSync(openApiPath)) {
+      console.error(chalk.red(`Error: OpenAPI spec file not found: ${openApiPath}`));
+      process.exit(1);
+    }
+
+    try {
+      console.log(chalk.blue(`🔄 Converting OpenAPI spec: ${chalk.bold(path.basename(openApiPath))}...`));
+      convertOpenAPIToBell(openApiPath, path.resolve(options.output));
+      console.log(chalk.green(`\n✔ Conversion complete! Files saved to: ${chalk.bold(options.output)}`));
+    } catch (err: any) {
+      console.error(chalk.red(`\n✖ Error during conversion:`));
       console.error(chalk.red(err.message));
       process.exit(1);
     }
@@ -260,7 +284,7 @@ if (cFlagIdx !== -1 && cFlagIdx + 1 < process.argv.length) {
   startRepl();
 } else {
   // Python-style: `bell <file.bel> [options]` — direct file invocation
-  const knownSubcommands = new Set(['run', 'convert', 'format', 'init', 'skill', 'help']);
+  const knownSubcommands = new Set(['run', 'convert', 'openapi', 'format', 'init', 'skill', 'help']);
   const firstArg = process.argv[2];
   if (firstArg && !firstArg.startsWith('-') && !knownSubcommands.has(firstArg) && firstArg.endsWith('.bel')) {
     // Rewrite argv so commander sees it as `bell run <file> [rest...]`

--- a/packages/core/src/converters/openapi.ts
+++ b/packages/core/src/converters/openapi.ts
@@ -1,0 +1,499 @@
+import * as fs from 'fs';
+import * as path from 'path';
+import chalk from 'chalk';
+import * as yaml from 'js-yaml';
+
+// --- OpenAPI 3.x type definitions ---
+
+interface OpenAPISpec {
+  openapi: string;
+  info: { title?: string; version?: string };
+  servers?: Server[];
+  paths?: Record<string, PathItem>;
+  components?: {
+    securitySchemes?: Record<string, SecurityScheme>;
+    schemas?: Record<string, SchemaObject | Reference>;
+  };
+  security?: SecurityRequirement[];
+}
+
+interface Server {
+  url: string;
+  description?: string;
+  variables?: Record<string, { default: string }>;
+}
+
+interface PathItem {
+  parameters?: (Parameter | Reference)[];
+  get?: Operation;
+  put?: Operation;
+  post?: Operation;
+  delete?: Operation;
+  options?: Operation;
+  head?: Operation;
+  patch?: Operation;
+}
+
+interface Operation {
+  tags?: string[];
+  summary?: string;
+  description?: string;
+  operationId?: string;
+  parameters?: (Parameter | Reference)[];
+  requestBody?: RequestBody | Reference;
+  responses?: Record<string, unknown>;
+  security?: SecurityRequirement[];
+}
+
+interface Parameter {
+  name: string;
+  in: 'query' | 'header' | 'path' | 'cookie';
+  required?: boolean;
+  schema?: SchemaObject | Reference;
+  example?: unknown;
+}
+
+interface RequestBody {
+  content: Record<string, MediaType>;
+  required?: boolean;
+}
+
+interface MediaType {
+  schema?: SchemaObject | Reference;
+  example?: unknown;
+  examples?: Record<string, Example | Reference>;
+}
+
+interface Example {
+  value?: unknown;
+}
+
+interface SchemaObject {
+  type?: string | string[];
+  properties?: Record<string, SchemaObject | Reference>;
+  items?: SchemaObject | Reference;
+  enum?: unknown[];
+  example?: unknown;
+  default?: unknown;
+  allOf?: (SchemaObject | Reference)[];
+  oneOf?: (SchemaObject | Reference)[];
+  anyOf?: (SchemaObject | Reference)[];
+  format?: string;
+  '$ref'?: string;
+}
+
+interface Reference {
+  '$ref': string;
+}
+
+type SecurityRequirement = Record<string, string[]>;
+
+interface SecurityScheme {
+  type: 'apiKey' | 'http' | 'oauth2' | 'openIdConnect';
+  scheme?: string;
+  in?: 'query' | 'header' | 'cookie';
+  name?: string;
+}
+
+interface EnvInfo {
+  hasEnvFile: boolean;
+  keys: string[];
+}
+
+// --- Public API ---
+
+export function convertOpenAPIToBell(openApiPath: string, outputDir: string): void {
+  const content = readFile(openApiPath);
+  const spec = parseSpec(openApiPath, content);
+  validateSpec(spec);
+
+  if (!fs.existsSync(outputDir)) {
+    fs.mkdirSync(outputDir, { recursive: true });
+  }
+
+  console.log(chalk.gray(`  API: ${chalk.bold(spec.info?.title || 'Unnamed')} v${spec.info?.version || '?'}`));
+
+  const servers = spec.servers ?? [];
+  const envKeys = computeEnvKeys(servers);
+  const envInfo: EnvInfo = { hasEnvFile: servers.length > 0, keys: envKeys };
+
+  if (envInfo.hasEnvFile) {
+    writeEnvFile(servers, envKeys, outputDir);
+    console.log(chalk.gray(`  Generated env.json with ${servers.length} server(s)`));
+  }
+
+  let fileCount = 0;
+  const paths = spec.paths ?? {};
+
+  for (const [apiPath, pathItem] of Object.entries(paths)) {
+    if (!pathItem) continue;
+    const pathLevelParams = resolveParams(pathItem.parameters ?? [], spec);
+
+    for (const method of ['get', 'post', 'put', 'patch', 'delete', 'options', 'head'] as const) {
+      const operation = pathItem[method];
+      if (!operation) continue;
+
+      const dirName = getOperationDir(operation, apiPath);
+      const opDir = dirName ? path.join(outputDir, dirName) : outputDir;
+      if (!fs.existsSync(opDir)) {
+        fs.mkdirSync(opDir, { recursive: true });
+      }
+
+      const fileName = getFileName(operation, apiPath, method);
+      const envRelPath = dirName ? '../env.json' : 'env.json';
+      const allParams = deduplicateParams([
+        ...pathLevelParams,
+        ...resolveParams(operation.parameters ?? [], spec),
+      ]);
+
+      const bellContent = generateBellFile(method.toUpperCase(), apiPath, operation, allParams, spec, envInfo, envRelPath);
+      fs.writeFileSync(path.join(opDir, fileName), bellContent, 'utf8');
+      fileCount++;
+    }
+  }
+
+  console.log(chalk.gray(`  Generated ${fileCount} .bel file(s)`));
+}
+
+// --- Internal helpers ---
+
+function readFile(filePath: string): string {
+  try {
+    return fs.readFileSync(filePath, 'utf8');
+  } catch (err: any) {
+    throw new Error(`Failed to read file: ${err.message}`);
+  }
+}
+
+function parseSpec(filePath: string, content: string): OpenAPISpec {
+  const ext = path.extname(filePath).toLowerCase();
+  if (ext === '.yaml' || ext === '.yml') {
+    try {
+      return yaml.load(content) as OpenAPISpec;
+    } catch (err: any) {
+      throw new Error(`Failed to parse OpenAPI YAML: ${err.message}`);
+    }
+  }
+  try {
+    return JSON.parse(content);
+  } catch (err: any) {
+    throw new Error(`Failed to parse OpenAPI JSON: ${err.message}`);
+  }
+}
+
+function validateSpec(spec: OpenAPISpec): void {
+  if ((spec as any).swagger) {
+    throw new Error(`Unsupported OpenAPI version: Swagger ${(spec as any).swagger} is not supported. Only OpenAPI 3.x is supported.`);
+  }
+  if (!spec?.openapi) {
+    throw new Error('Invalid OpenAPI spec: missing "openapi" version field.');
+  }
+  if (!spec.openapi.startsWith('3.')) {
+    throw new Error(`Unsupported OpenAPI version: ${spec.openapi}. Only OpenAPI 3.x is supported.`);
+  }
+  if (!spec.paths || typeof spec.paths !== 'object') {
+    throw new Error('Invalid OpenAPI spec: missing or invalid "paths".');
+  }
+}
+
+function computeEnvKeys(servers: Server[]): string[] {
+  return servers.map((server, index) => {
+    if (server.description) return sanitizeName(server.description);
+    return index === 0 ? 'default' : `server_${index}`;
+  });
+}
+
+function writeEnvFile(servers: Server[], keys: string[], outputDir: string): void {
+  const config: Record<string, { url: string }> = {};
+  servers.forEach((server, index) => {
+    let url = server.url;
+    for (const [varName, varDef] of Object.entries(server.variables ?? {})) {
+      url = url.replace(`{${varName}}`, varDef.default);
+    }
+    config[keys[index]] = { url: url.replace(/\/$/, '') };
+  });
+  fs.writeFileSync(path.join(outputDir, 'env.json'), JSON.stringify(config, null, 2) + '\n', 'utf8');
+}
+
+function resolveParams(params: (Parameter | Reference)[], spec: OpenAPISpec): Parameter[] {
+  return params
+    .map(p => (isReference(p) ? resolveRef<Parameter>(p['$ref'], spec) : p))
+    .filter((p): p is Parameter => p !== null);
+}
+
+function getOperationDir(operation: Operation, apiPath: string): string {
+  const tag = operation.tags?.[0];
+  if (tag) return sanitizeName(tag);
+  const segments = apiPath.split('/').filter(s => s && !s.startsWith('{'));
+  return segments.length > 0 ? sanitizeName(segments[0]) : '';
+}
+
+function getFileName(operation: Operation, apiPath: string, method: string): string {
+  const name = operation.operationId
+    ? sanitizeName(operation.operationId)
+    : getOperationName(apiPath, method);
+  return `${name}.${method.toUpperCase()}.bel`;
+}
+
+function getOperationName(apiPath: string, method: string): string {
+  const segments = apiPath.split('/').filter(Boolean).map(s => s.replace(/[{}]/g, ''));
+  return sanitizeName(`${method}_${segments.join('_')}` || method);
+}
+
+function sanitizeName(name: string): string {
+  return name
+    .replace(/([a-z])([A-Z])/g, '$1_$2')  // camelCase → snake_case
+    .replace(/[^a-z0-9]/gi, '_')
+    .toLowerCase();
+}
+
+function toBellVarName(name: string): string {
+  return name.replace(/-/g, '_').replace(/[^a-zA-Z0-9_]/g, '');
+}
+
+function deduplicateParams(params: Parameter[]): Parameter[] {
+  const seen = new Set<string>();
+  return params.filter(p => {
+    const key = `${p.in}:${p.name}`;
+    if (seen.has(key)) return false;
+    seen.add(key);
+    return true;
+  });
+}
+
+function isReference(obj: unknown): obj is Reference {
+  return typeof obj === 'object' && obj !== null && '$ref' in obj;
+}
+
+function resolveRef<T>(ref: string, spec: OpenAPISpec): T | null {
+  if (!ref.startsWith('#/')) return null;
+  const parts = ref.slice(2).split('/');
+  let current: unknown = spec;
+  for (const part of parts) {
+    current = (current as Record<string, unknown>)?.[part];
+    if (current === undefined) return null;
+  }
+  return current as T;
+}
+
+function resolveSchema(schema: SchemaObject | Reference | undefined, spec: OpenAPISpec): SchemaObject | null {
+  if (!schema) return null;
+  if (isReference(schema)) return resolveRef<SchemaObject>(schema['$ref'], spec);
+  return schema;
+}
+
+function generateExampleValue(schema: SchemaObject | Reference | undefined, spec: OpenAPISpec, depth = 0): unknown {
+  if (!schema) return 'example';
+  if (depth > 4) return null;
+
+  if (isReference(schema)) {
+    const resolved = resolveRef<SchemaObject>(schema['$ref'], spec);
+    return resolved ? generateExampleValue(resolved, spec, depth) : 'example';
+  }
+
+  if (schema.example !== undefined) return schema.example;
+  if (schema.default !== undefined) return schema.default;
+  if (schema.enum?.length) return schema.enum[0];
+
+  const first = (arr?: (SchemaObject | Reference)[]) => arr?.[0];
+  if (schema.allOf) return generateExampleValue(first(schema.allOf), spec, depth);
+  if (schema.oneOf) return generateExampleValue(first(schema.oneOf), spec, depth);
+  if (schema.anyOf) return generateExampleValue(first(schema.anyOf), spec, depth);
+
+  const type = Array.isArray(schema.type) ? schema.type[0] : schema.type;
+
+  switch (type) {
+    case 'string':
+      if (schema.format === 'date-time') return '2024-01-01T00:00:00Z';
+      if (schema.format === 'date') return '2024-01-01';
+      if (schema.format === 'email') return 'user@example.com';
+      if (schema.format === 'uuid') return '00000000-0000-0000-0000-000000000000';
+      if (schema.format === 'uri') return 'https://example.com';
+      return 'example';
+    case 'integer':
+    case 'number':
+      return 0;
+    case 'boolean':
+      return true;
+    case 'array':
+      return schema.items ? [generateExampleValue(schema.items, spec, depth + 1)] : [];
+    case 'object': {
+      if (!schema.properties) return {};
+      const obj: Record<string, unknown> = {};
+      for (const [key, prop] of Object.entries(schema.properties)) {
+        obj[key] = generateExampleValue(prop, spec, depth + 1);
+      }
+      return obj;
+    }
+    default:
+      return 'example';
+  }
+}
+
+function generateBellFile(
+  method: string,
+  apiPath: string,
+  operation: Operation,
+  allParams: Parameter[],
+  spec: OpenAPISpec,
+  envInfo: EnvInfo,
+  envRelPath: string,
+): string {
+  const lines: string[] = [];
+
+  // Header comment
+  const title = operation.summary || operation.operationId || `${method} ${apiPath}`;
+  lines.push(`### ${title}`);
+  if (operation.description && operation.description !== operation.summary) {
+    lines.push(`### ${operation.description}`);
+  }
+  lines.push('');
+
+  // Env import + selection
+  if (envInfo.hasEnvFile) {
+    lines.push(`import "${envRelPath}"`);
+    if (envInfo.keys.length === 1) {
+      lines.push(`env "${envInfo.keys[0]}"`);
+    } else {
+      lines.push(`env ${envInfo.keys.map(k => `"${k}"`).join(' | ')}`);
+    }
+    lines.push('');
+  }
+
+  // Path parameter declarations
+  const pathParams = allParams.filter(p => p.in === 'path');
+  if (pathParams.length > 0) {
+    for (const param of pathParams) {
+      const schema = resolveSchema(param.schema, spec) ?? undefined;
+      const example = param.example ?? generateExampleValue(schema, spec);
+      const val = typeof example === 'string' ? `"${example}"` : JSON.stringify(example);
+      lines.push(`${toBellVarName(param.name)} = ${val}`);
+    }
+    lines.push('');
+  }
+
+  // URL
+  const bellPath = apiPath.replace(/{([^}]+)}/g, (_, n) => `{${toBellVarName(n)}}`);
+  if (envInfo.hasEnvFile) {
+    lines.push(`path "${bellPath}"`);
+  } else {
+    lines.push(`url "https://your-api.com${bellPath}"`);
+  }
+  lines.push('');
+
+  // Query parameters
+  const queryParams = allParams.filter(p => p.in === 'query');
+  if (queryParams.length > 0) {
+    for (const param of queryParams) {
+      const schema = resolveSchema(param.schema, spec) ?? undefined;
+      const example = param.example ?? generateExampleValue(schema, spec);
+      const val = typeof example === 'string' ? `"${example}"` : JSON.stringify(example);
+      lines.push(`param "${param.name}" ${val}`);
+    }
+    lines.push('');
+  }
+
+  // Explicit header parameters
+  const headerParams = allParams.filter(p => p.in === 'header');
+  if (headerParams.length > 0) {
+    for (const param of headerParams) {
+      const schema = resolveSchema(param.schema, spec) ?? undefined;
+      const example = param.example ?? generateExampleValue(schema, spec);
+      const val = typeof example === 'string' ? `"${example}"` : JSON.stringify(example);
+      lines.push(`header "${param.name}" ${val}`);
+    }
+    lines.push('');
+  }
+
+  // Security headers (commented out)
+  const securityLines = buildSecurityLines(operation, spec);
+  if (securityLines.length > 0) {
+    lines.push(...securityLines);
+    lines.push('');
+  }
+
+  // Request body
+  if (operation.requestBody) {
+    const bodyLines = buildBodyLines(operation.requestBody, spec);
+    if (bodyLines.length > 0) {
+      lines.push(...bodyLines);
+      lines.push('');
+    }
+  }
+
+  // HTTP method
+  lines.push(method);
+  lines.push('');
+
+  // Expect success status
+  const responses = operation.responses ?? {};
+  const successCodes = Object.keys(responses)
+    .filter(c => /^2\d\d$/.test(c))
+    .map(Number);
+  const expectedStatus = successCodes.length > 0 ? Math.min(...successCodes) : 200;
+  lines.push(`expect response.status === ${expectedStatus}`);
+
+  return lines.join('\n') + '\n';
+}
+
+function buildSecurityLines(operation: Operation, spec: OpenAPISpec): string[] {
+  const security = operation.security ?? spec.security ?? [];
+  const schemes = spec.components?.securitySchemes ?? {};
+  const lines: string[] = [];
+  const seen = new Set<string>();
+
+  for (const req of security) {
+    for (const name of Object.keys(req)) {
+      const scheme = schemes[name];
+      if (!scheme || seen.has(name)) continue;
+      seen.add(name);
+
+      if (scheme.type === 'http') {
+        if (scheme.scheme === 'bearer') {
+          lines.push(`# header "Authorization" "Bearer YOUR_TOKEN"`);
+        } else if (scheme.scheme === 'basic') {
+          lines.push(`# header "Authorization" "Basic YOUR_CREDENTIALS"`);
+        }
+      } else if (scheme.type === 'apiKey') {
+        if (scheme.in === 'header') {
+          lines.push(`# header "${scheme.name}" "YOUR_API_KEY"`);
+        } else if (scheme.in === 'query') {
+          lines.push(`# param "${scheme.name}" "YOUR_API_KEY"`);
+        }
+      } else if (scheme.type === 'oauth2') {
+        lines.push(`# header "Authorization" "Bearer YOUR_OAUTH_TOKEN"`);
+      }
+    }
+  }
+
+  return lines;
+}
+
+function buildBodyLines(requestBody: RequestBody | Reference, spec: OpenAPISpec): string[] {
+  const body = isReference(requestBody)
+    ? resolveRef<RequestBody>(requestBody['$ref'], spec)
+    : requestBody;
+  if (!body?.content) return [];
+
+  const mediaType = body.content['application/json'] ?? Object.values(body.content)[0];
+  if (!mediaType) return [];
+
+  let example: unknown;
+  if (mediaType.example !== undefined) {
+    example = mediaType.example;
+  } else if (mediaType.examples) {
+    const first = Object.values(mediaType.examples)[0];
+    if (first && !isReference(first) && 'value' in first) {
+      example = first.value;
+    }
+  } else if (mediaType.schema) {
+    const schema = resolveSchema(mediaType.schema, spec);
+    example = generateExampleValue(schema ?? undefined, spec);
+  }
+
+  if (example === undefined) return [];
+  if (typeof example === 'object' && example !== null) {
+    return [`body ${JSON.stringify(example, null, 2)}`];
+  }
+  return [`body ${JSON.stringify(example)}`];
+}

--- a/packages/core/src/skill/bell-skill.md
+++ b/packages/core/src/skill/bell-skill.md
@@ -263,6 +263,7 @@ bell <file.bel>                   # shorthand (no subcommand needed)
 bell init                         # create a starter bell/ folder
 bell format <file.bel>            # format a file
 bell convert <postman.json>       # convert Postman collection
+bell openapi <spec.json|yaml>     # convert OpenAPI 3.x spec to Bell files
 bell skill                        # print this skill reference
 bell skill --install              # install as Claude Code slash command
 ```

--- a/packages/core/src/skill/bell-skill.md
+++ b/packages/core/src/skill/bell-skill.md
@@ -262,7 +262,7 @@ bell run <file.bel> -e prod       # run with environment
 bell <file.bel>                   # shorthand (no subcommand needed)
 bell init                         # create a starter bell/ folder
 bell format <file.bel>            # format a file
-bell convert <postman.json>       # convert Postman collection
+bell postman <collection.json>     # convert Postman collection
 bell openapi <spec.json|yaml>     # convert OpenAPI 3.x spec to Bell files
 bell skill                        # print this skill reference
 bell skill --install              # install as Claude Code slash command

--- a/packages/core/test/openapi.test.ts
+++ b/packages/core/test/openapi.test.ts
@@ -1,0 +1,394 @@
+import { expect } from 'chai';
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import { convertOpenAPIToBell } from '../src/converters/openapi';
+
+// __dirname is dist/test/ at runtime; fixtures live in the source test/ directory
+function fixturePath(caseName: string, file = 'input.json'): string {
+  return path.join(__dirname, '..', '..', 'test', 'openapi', caseName, file);
+}
+
+function expectedFile(caseName: string, ...parts: string[]): string {
+  return fs.readFileSync(
+    path.join(__dirname, '..', '..', 'test', 'openapi', caseName, 'expected', ...parts),
+    'utf8'
+  );
+}
+
+describe('OpenAPI Converter', () => {
+  let tmpDir: string;
+
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'bell-openapi-'));
+  });
+
+  afterEach(() => {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  // --- Happy path ---
+
+  it('converts a simple GET operation without servers', () => {
+    convertOpenAPIToBell(fixturePath('simple-get'), tmpDir);
+    const output = fs.readFileSync(path.join(tmpDir, 'users', 'list_users.GET.bel'), 'utf8');
+    expect(output).to.equal(expectedFile('simple-get', 'users', 'list_users.GET.bel'));
+  });
+
+  it('generates env.json and uses path statements when servers are defined', () => {
+    convertOpenAPIToBell(fixturePath('with-servers'), tmpDir);
+
+    const envOutput = fs.readFileSync(path.join(tmpDir, 'env.json'), 'utf8');
+    expect(envOutput).to.equal(expectedFile('with-servers', 'env.json'));
+
+    const belOutput = fs.readFileSync(path.join(tmpDir, 'users', 'list_users.GET.bel'), 'utf8');
+    expect(belOutput).to.equal(expectedFile('with-servers', 'users', 'list_users.GET.bel'));
+  });
+
+  it('generates a body block from the request body schema', () => {
+    convertOpenAPIToBell(fixturePath('post-with-body'), tmpDir);
+    const output = fs.readFileSync(path.join(tmpDir, 'users', 'create_user.POST.bel'), 'utf8');
+    expect(output).to.equal(expectedFile('post-with-body', 'users', 'create_user.POST.bel'));
+  });
+
+  it('declares path parameters as variables and emits query params', () => {
+    convertOpenAPIToBell(fixturePath('path-and-query-params'), tmpDir);
+    const output = fs.readFileSync(path.join(tmpDir, 'users', 'get_user.GET.bel'), 'utf8');
+    expect(output).to.equal(expectedFile('path-and-query-params', 'users', 'get_user.GET.bel'));
+  });
+
+  it('emits commented security headers for bearer auth', () => {
+    convertOpenAPIToBell(fixturePath('with-security'), tmpDir);
+    const output = fs.readFileSync(path.join(tmpDir, 'users', 'list_users.GET.bel'), 'utf8');
+    expect(output).to.equal(expectedFile('with-security', 'users', 'list_users.GET.bel'));
+  });
+
+  it('parses YAML input files', () => {
+    convertOpenAPIToBell(fixturePath('yaml-format', 'input.yaml'), tmpDir);
+    const output = fs.readFileSync(path.join(tmpDir, 'users', 'list_users.GET.bel'), 'utf8');
+    expect(output).to.equal(expectedFile('yaml-format', 'users', 'list_users.GET.bel'));
+  });
+
+  it('uses operation tags as subdirectory names', () => {
+    convertOpenAPIToBell(fixturePath('tags'), tmpDir);
+    const users = fs.readFileSync(path.join(tmpDir, 'users', 'list_users.GET.bel'), 'utf8');
+    const posts = fs.readFileSync(path.join(tmpDir, 'posts', 'list_posts.GET.bel'), 'utf8');
+    expect(users).to.equal(expectedFile('tags', 'users', 'list_users.GET.bel'));
+    expect(posts).to.equal(expectedFile('tags', 'posts', 'list_posts.GET.bel'));
+  });
+
+  it('generates one file per HTTP method on the same path', () => {
+    convertOpenAPIToBell(fixturePath('multiple-methods'), tmpDir);
+    const getOutput = fs.readFileSync(path.join(tmpDir, 'articles', 'list_articles.GET.bel'), 'utf8');
+    const postOutput = fs.readFileSync(path.join(tmpDir, 'articles', 'create_article.POST.bel'), 'utf8');
+    expect(getOutput).to.equal(expectedFile('multiple-methods', 'articles', 'list_articles.GET.bel'));
+    expect(postOutput).to.equal(expectedFile('multiple-methods', 'articles', 'create_article.POST.bel'));
+  });
+
+  // --- Schema example generation ---
+
+  it('uses the example field from the spec when present', () => {
+    const spec = {
+      openapi: '3.0.0',
+      info: { title: 'T', version: '1' },
+      paths: {
+        '/ping': {
+          get: {
+            operationId: 'ping',
+            summary: 'Ping',
+            requestBody: {
+              content: {
+                'application/json': {
+                  schema: { type: 'string', example: 'hello' },
+                },
+              },
+            },
+            responses: { '200': { description: 'ok' } },
+          },
+        },
+      },
+    };
+    const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'bell-oa-'));
+    const specPath = path.join(tmp, 'spec.json');
+    fs.writeFileSync(specPath, JSON.stringify(spec));
+    try {
+      convertOpenAPIToBell(specPath, tmp);
+      const output = fs.readFileSync(path.join(tmp, 'ping', 'ping.GET.bel'), 'utf8');
+      expect(output).to.include('body "hello"');
+    } finally {
+      fs.rmSync(tmp, { recursive: true, force: true });
+    }
+  });
+
+  it('generates format-specific string examples (email, uuid, date)', () => {
+    const spec = {
+      openapi: '3.0.0',
+      info: { title: 'T', version: '1' },
+      paths: {
+        '/items': {
+          post: {
+            operationId: 'createItem',
+            summary: 'Create',
+            requestBody: {
+              content: {
+                'application/json': {
+                  schema: {
+                    type: 'object',
+                    properties: {
+                      email: { type: 'string', format: 'email' },
+                      id: { type: 'string', format: 'uuid' },
+                      date: { type: 'string', format: 'date' },
+                    },
+                  },
+                },
+              },
+            },
+            responses: { '200': { description: 'ok' } },
+          },
+        },
+      },
+    };
+    const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'bell-oa-'));
+    const specPath = path.join(tmp, 'spec.json');
+    fs.writeFileSync(specPath, JSON.stringify(spec));
+    try {
+      convertOpenAPIToBell(specPath, tmp);
+      const output = fs.readFileSync(path.join(tmp, 'items', 'create_item.POST.bel'), 'utf8');
+      expect(output).to.include('"user@example.com"');
+      expect(output).to.include('"00000000-0000-0000-0000-000000000000"');
+      expect(output).to.include('"2024-01-01"');
+    } finally {
+      fs.rmSync(tmp, { recursive: true, force: true });
+    }
+  });
+
+  it('picks the first enum value as the example', () => {
+    const spec = {
+      openapi: '3.0.0',
+      info: { title: 'T', version: '1' },
+      paths: {
+        '/items': {
+          get: {
+            operationId: 'listItems',
+            summary: 'List',
+            parameters: [
+              { name: 'status', in: 'query', schema: { type: 'string', enum: ['active', 'inactive'] } },
+            ],
+            responses: { '200': { description: 'ok' } },
+          },
+        },
+      },
+    };
+    const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'bell-oa-'));
+    const specPath = path.join(tmp, 'spec.json');
+    fs.writeFileSync(specPath, JSON.stringify(spec));
+    try {
+      convertOpenAPIToBell(specPath, tmp);
+      const output = fs.readFileSync(path.join(tmp, 'items', 'list_items.GET.bel'), 'utf8');
+      expect(output).to.include('param "status" "active"');
+    } finally {
+      fs.rmSync(tmp, { recursive: true, force: true });
+    }
+  });
+
+  it('resolves $ref schemas from components', () => {
+    const spec = {
+      openapi: '3.0.0',
+      info: { title: 'T', version: '1' },
+      components: {
+        schemas: {
+          User: {
+            type: 'object',
+            properties: { name: { type: 'string' } },
+          },
+        },
+      },
+      paths: {
+        '/users': {
+          post: {
+            operationId: 'createUser',
+            summary: 'Create user',
+            requestBody: {
+              content: {
+                'application/json': {
+                  schema: { '$ref': '#/components/schemas/User' },
+                },
+              },
+            },
+            responses: { '201': { description: 'Created' } },
+          },
+        },
+      },
+    };
+    const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'bell-oa-'));
+    const specPath = path.join(tmp, 'spec.json');
+    fs.writeFileSync(specPath, JSON.stringify(spec));
+    try {
+      convertOpenAPIToBell(specPath, tmp);
+      const output = fs.readFileSync(path.join(tmp, 'users', 'create_user.POST.bel'), 'utf8');
+      expect(output).to.include('"name": "example"');
+    } finally {
+      fs.rmSync(tmp, { recursive: true, force: true });
+    }
+  });
+
+  // --- Security scheme variants ---
+
+  it('emits api-key header comment for apiKey security', () => {
+    const spec = {
+      openapi: '3.0.0',
+      info: { title: 'T', version: '1' },
+      components: {
+        securitySchemes: {
+          apiKey: { type: 'apiKey', in: 'header', name: 'X-API-Key' },
+        },
+      },
+      security: [{ apiKey: [] }],
+      paths: {
+        '/items': {
+          get: {
+            operationId: 'listItems',
+            summary: 'List',
+            responses: { '200': { description: 'ok' } },
+          },
+        },
+      },
+    };
+    const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'bell-oa-'));
+    const specPath = path.join(tmp, 'spec.json');
+    fs.writeFileSync(specPath, JSON.stringify(spec));
+    try {
+      convertOpenAPIToBell(specPath, tmp);
+      const output = fs.readFileSync(path.join(tmp, 'items', 'list_items.GET.bel'), 'utf8');
+      expect(output).to.include('# header "X-API-Key" "YOUR_API_KEY"');
+    } finally {
+      fs.rmSync(tmp, { recursive: true, force: true });
+    }
+  });
+
+  it('emits query param comment for query-based apiKey security', () => {
+    const spec = {
+      openapi: '3.0.0',
+      info: { title: 'T', version: '1' },
+      components: {
+        securitySchemes: {
+          apiKey: { type: 'apiKey', in: 'query', name: 'api_key' },
+        },
+      },
+      security: [{ apiKey: [] }],
+      paths: {
+        '/items': {
+          get: {
+            operationId: 'listItems',
+            summary: 'List',
+            responses: { '200': { description: 'ok' } },
+          },
+        },
+      },
+    };
+    const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'bell-oa-'));
+    const specPath = path.join(tmp, 'spec.json');
+    fs.writeFileSync(specPath, JSON.stringify(spec));
+    try {
+      convertOpenAPIToBell(specPath, tmp);
+      const output = fs.readFileSync(path.join(tmp, 'items', 'list_items.GET.bel'), 'utf8');
+      expect(output).to.include('# param "api_key" "YOUR_API_KEY"');
+    } finally {
+      fs.rmSync(tmp, { recursive: true, force: true });
+    }
+  });
+
+  it('uses the lowest 2xx status code in the expect assertion', () => {
+    const spec = {
+      openapi: '3.0.0',
+      info: { title: 'T', version: '1' },
+      paths: {
+        '/things': {
+          post: {
+            operationId: 'createThing',
+            summary: 'Create',
+            responses: {
+              '201': { description: 'Created' },
+              '400': { description: 'Bad request' },
+            },
+          },
+        },
+      },
+    };
+    const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'bell-oa-'));
+    const specPath = path.join(tmp, 'spec.json');
+    fs.writeFileSync(specPath, JSON.stringify(spec));
+    try {
+      convertOpenAPIToBell(specPath, tmp);
+      const output = fs.readFileSync(path.join(tmp, 'things', 'create_thing.POST.bel'), 'utf8');
+      expect(output).to.include('expect response.status === 201');
+    } finally {
+      fs.rmSync(tmp, { recursive: true, force: true });
+    }
+  });
+
+  // --- Error handling ---
+
+  it('throws when the file does not exist', () => {
+    expect(() =>
+      convertOpenAPIToBell('/nonexistent/path/spec.json', tmpDir)
+    ).to.throw(/Failed to read file/);
+  });
+
+  it('throws on invalid JSON', () => {
+    const badPath = path.join(tmpDir, 'bad.json');
+    fs.writeFileSync(badPath, 'not json');
+    expect(() => convertOpenAPIToBell(badPath, tmpDir)).to.throw(/Failed to parse/);
+  });
+
+  it('throws on Swagger 2.0 specs', () => {
+    const swaggerPath = path.join(tmpDir, 'swagger.json');
+    fs.writeFileSync(swaggerPath, JSON.stringify({ swagger: '2.0', info: {}, paths: {} }));
+    expect(() => convertOpenAPIToBell(swaggerPath, tmpDir)).to.throw(/Unsupported OpenAPI version/);
+  });
+
+  it('throws when paths is missing', () => {
+    const specPath = path.join(tmpDir, 'spec.json');
+    fs.writeFileSync(specPath, JSON.stringify({ openapi: '3.0.0', info: { title: 'T', version: '1' } }));
+    expect(() => convertOpenAPIToBell(specPath, tmpDir)).to.throw(/missing or invalid "paths"/);
+  });
+
+  it('creates the output directory if it does not exist', () => {
+    const nestedOut = path.join(tmpDir, 'a', 'b', 'c');
+    convertOpenAPIToBell(fixturePath('simple-get'), nestedOut);
+    expect(fs.existsSync(path.join(nestedOut, 'users', 'list_users.GET.bel'))).to.be.true;
+  });
+
+  it('deduplicates parameters shared between path and operation', () => {
+    const spec = {
+      openapi: '3.0.0',
+      info: { title: 'T', version: '1' },
+      paths: {
+        '/users/{userId}': {
+          parameters: [
+            { name: 'userId', in: 'path', required: true, schema: { type: 'string' } },
+          ],
+          get: {
+            operationId: 'getUser',
+            summary: 'Get user',
+            parameters: [
+              { name: 'userId', in: 'path', required: true, schema: { type: 'string' } },
+            ],
+            responses: { '200': { description: 'ok' } },
+          },
+        },
+      },
+    };
+    const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'bell-oa-'));
+    const specPath = path.join(tmp, 'spec.json');
+    fs.writeFileSync(specPath, JSON.stringify(spec));
+    try {
+      convertOpenAPIToBell(specPath, tmp);
+      const output = fs.readFileSync(path.join(tmp, 'users', 'get_user.GET.bel'), 'utf8');
+      const matches = output.match(/userId = /g);
+      expect(matches).to.have.length(1);
+    } finally {
+      fs.rmSync(tmp, { recursive: true, force: true });
+    }
+  });
+});

--- a/packages/core/test/openapi/multiple-methods/expected/articles/create_article.POST.bel
+++ b/packages/core/test/openapi/multiple-methods/expected/articles/create_article.POST.bel
@@ -1,0 +1,11 @@
+### Create article
+
+url "https://your-api.com/articles"
+
+body {
+  "title": "example"
+}
+
+POST
+
+expect response.status === 201

--- a/packages/core/test/openapi/multiple-methods/expected/articles/list_articles.GET.bel
+++ b/packages/core/test/openapi/multiple-methods/expected/articles/list_articles.GET.bel
@@ -1,0 +1,7 @@
+### List articles
+
+url "https://your-api.com/articles"
+
+GET
+
+expect response.status === 200

--- a/packages/core/test/openapi/multiple-methods/input.json
+++ b/packages/core/test/openapi/multiple-methods/input.json
@@ -1,0 +1,30 @@
+{
+  "openapi": "3.0.0",
+  "info": { "title": "Test API", "version": "1.0.0" },
+  "paths": {
+    "/articles": {
+      "get": {
+        "operationId": "listArticles",
+        "summary": "List articles",
+        "responses": { "200": { "description": "OK" } }
+      },
+      "post": {
+        "operationId": "createArticle",
+        "summary": "Create article",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "title": { "type": "string" }
+                }
+              }
+            }
+          }
+        },
+        "responses": { "201": { "description": "Created" } }
+      }
+    }
+  }
+}

--- a/packages/core/test/openapi/path-and-query-params/expected/users/get_user.GET.bel
+++ b/packages/core/test/openapi/path-and-query-params/expected/users/get_user.GET.bel
@@ -1,0 +1,11 @@
+### Get a user
+
+userId = "example"
+
+url "https://your-api.com/users/{userId}"
+
+param "include" "profile"
+
+GET
+
+expect response.status === 200

--- a/packages/core/test/openapi/path-and-query-params/input.json
+++ b/packages/core/test/openapi/path-and-query-params/input.json
@@ -1,0 +1,28 @@
+{
+  "openapi": "3.0.0",
+  "info": { "title": "Test API", "version": "1.0.0" },
+  "paths": {
+    "/users/{userId}": {
+      "get": {
+        "operationId": "getUser",
+        "summary": "Get a user",
+        "parameters": [
+          {
+            "name": "userId",
+            "in": "path",
+            "required": true,
+            "schema": { "type": "string" }
+          },
+          {
+            "name": "include",
+            "in": "query",
+            "schema": { "type": "string", "enum": ["profile", "settings"] }
+          }
+        ],
+        "responses": {
+          "200": { "description": "Success" }
+        }
+      }
+    }
+  }
+}

--- a/packages/core/test/openapi/post-with-body/expected/users/create_user.POST.bel
+++ b/packages/core/test/openapi/post-with-body/expected/users/create_user.POST.bel
@@ -1,0 +1,13 @@
+### Create a user
+
+url "https://your-api.com/users"
+
+body {
+  "name": "example",
+  "email": "user@example.com",
+  "age": 0
+}
+
+POST
+
+expect response.status === 201

--- a/packages/core/test/openapi/post-with-body/input.json
+++ b/packages/core/test/openapi/post-with-body/input.json
@@ -1,0 +1,30 @@
+{
+  "openapi": "3.0.0",
+  "info": { "title": "Test API", "version": "1.0.0" },
+  "paths": {
+    "/users": {
+      "post": {
+        "operationId": "createUser",
+        "summary": "Create a user",
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "name": { "type": "string" },
+                  "email": { "type": "string", "format": "email" },
+                  "age": { "type": "integer" }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "201": { "description": "Created" }
+        }
+      }
+    }
+  }
+}

--- a/packages/core/test/openapi/simple-get/expected/users/list_users.GET.bel
+++ b/packages/core/test/openapi/simple-get/expected/users/list_users.GET.bel
@@ -1,0 +1,7 @@
+### List all users
+
+url "https://your-api.com/users"
+
+GET
+
+expect response.status === 200

--- a/packages/core/test/openapi/simple-get/input.json
+++ b/packages/core/test/openapi/simple-get/input.json
@@ -1,0 +1,15 @@
+{
+  "openapi": "3.0.0",
+  "info": { "title": "Test API", "version": "1.0.0" },
+  "paths": {
+    "/users": {
+      "get": {
+        "operationId": "listUsers",
+        "summary": "List all users",
+        "responses": {
+          "200": { "description": "Success" }
+        }
+      }
+    }
+  }
+}

--- a/packages/core/test/openapi/tags/expected/posts/list_posts.GET.bel
+++ b/packages/core/test/openapi/tags/expected/posts/list_posts.GET.bel
@@ -1,0 +1,7 @@
+### List posts
+
+url "https://your-api.com/posts"
+
+GET
+
+expect response.status === 200

--- a/packages/core/test/openapi/tags/expected/users/list_users.GET.bel
+++ b/packages/core/test/openapi/tags/expected/users/list_users.GET.bel
@@ -1,0 +1,7 @@
+### List users
+
+url "https://your-api.com/users"
+
+GET
+
+expect response.status === 200

--- a/packages/core/test/openapi/tags/input.json
+++ b/packages/core/test/openapi/tags/input.json
@@ -1,0 +1,22 @@
+{
+  "openapi": "3.0.0",
+  "info": { "title": "Test API", "version": "1.0.0" },
+  "paths": {
+    "/users": {
+      "get": {
+        "tags": ["Users"],
+        "operationId": "listUsers",
+        "summary": "List users",
+        "responses": { "200": { "description": "OK" } }
+      }
+    },
+    "/posts": {
+      "get": {
+        "tags": ["Posts"],
+        "operationId": "listPosts",
+        "summary": "List posts",
+        "responses": { "200": { "description": "OK" } }
+      }
+    }
+  }
+}

--- a/packages/core/test/openapi/with-security/expected/users/list_users.GET.bel
+++ b/packages/core/test/openapi/with-security/expected/users/list_users.GET.bel
@@ -1,0 +1,9 @@
+### List users
+
+url "https://your-api.com/users"
+
+# header "Authorization" "Bearer YOUR_TOKEN"
+
+GET
+
+expect response.status === 200

--- a/packages/core/test/openapi/with-security/input.json
+++ b/packages/core/test/openapi/with-security/input.json
@@ -1,0 +1,24 @@
+{
+  "openapi": "3.0.0",
+  "info": { "title": "Test API", "version": "1.0.0" },
+  "components": {
+    "securitySchemes": {
+      "bearerAuth": {
+        "type": "http",
+        "scheme": "bearer"
+      }
+    }
+  },
+  "security": [{ "bearerAuth": [] }],
+  "paths": {
+    "/users": {
+      "get": {
+        "operationId": "listUsers",
+        "summary": "List users",
+        "responses": {
+          "200": { "description": "Success" }
+        }
+      }
+    }
+  }
+}

--- a/packages/core/test/openapi/with-servers/expected/env.json
+++ b/packages/core/test/openapi/with-servers/expected/env.json
@@ -1,0 +1,8 @@
+{
+  "production": {
+    "url": "https://api.example.com"
+  },
+  "staging": {
+    "url": "https://staging.api.example.com"
+  }
+}

--- a/packages/core/test/openapi/with-servers/expected/users/list_users.GET.bel
+++ b/packages/core/test/openapi/with-servers/expected/users/list_users.GET.bel
@@ -1,0 +1,10 @@
+### List all users
+
+import "../env.json"
+env "production" | "staging"
+
+path "/users"
+
+GET
+
+expect response.status === 200

--- a/packages/core/test/openapi/with-servers/input.json
+++ b/packages/core/test/openapi/with-servers/input.json
@@ -1,0 +1,19 @@
+{
+  "openapi": "3.0.0",
+  "info": { "title": "Test API", "version": "1.0.0" },
+  "servers": [
+    { "url": "https://api.example.com", "description": "Production" },
+    { "url": "https://staging.api.example.com", "description": "Staging" }
+  ],
+  "paths": {
+    "/users": {
+      "get": {
+        "operationId": "listUsers",
+        "summary": "List all users",
+        "responses": {
+          "200": { "description": "Success" }
+        }
+      }
+    }
+  }
+}

--- a/packages/core/test/openapi/yaml-format/expected/users/list_users.GET.bel
+++ b/packages/core/test/openapi/yaml-format/expected/users/list_users.GET.bel
@@ -1,0 +1,7 @@
+### List all users
+
+url "https://your-api.com/users"
+
+GET
+
+expect response.status === 200

--- a/packages/core/test/openapi/yaml-format/input.yaml
+++ b/packages/core/test/openapi/yaml-format/input.yaml
@@ -1,0 +1,12 @@
+openapi: "3.0.0"
+info:
+  title: Test API
+  version: "1.0.0"
+paths:
+  /users:
+    get:
+      operationId: listUsers
+      summary: List all users
+      responses:
+        "200":
+          description: Success


### PR DESCRIPTION
- New converter (packages/core/src/converters/openapi.ts):
  - Parses JSON and YAML OpenAPI 3.x specs (js-yaml)
  - Generates one .bel file per operation, grouped by tag or path segment
  - Emits env.json + import/path statements when servers are defined;
    falls back to placeholder url when no servers are present
  - Declares path parameters as Bell variables with example values
    derived from schema type, format, enum, or explicit example fields
  - Emits param/header statements for query and header parameters
  - Generates commented-out security headers (bearer, basic, apiKey, oauth2)
  - Generates body blocks from request body schemas via $ref resolution
  - Uses the lowest 2xx status code in the expect assertion
  - Detects and rejects Swagger 2.0 with a clear error message
  - Deduplicates parameters shared between path-level and operation-level
  - sanitizeName converts camelCase operationIds to snake_case filenames

- CLI: new `bell openapi <spec>` subcommand with -o/--output option

- Tests (packages/core/test/openapi.test.ts): 21 cases covering fixture
  comparisons, schema example generation, security schemes, error paths,
  $ref resolution, deduplication, and YAML input

- Docs: updated CLAUDE.md, README.md, and bell-skill.md

https://claude.ai/code/session_01Nu86swzbdHUEn8GNu8pZsg